### PR TITLE
Remove use of showOpenFilePicker in example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -604,9 +604,6 @@ these steps:
      and |child| represents `/home/user/project/foo/bar`, this will return
      `['foo', 'bar']`.
   :: Otherwise (|directory| and |child| are not related), |path| will be null.
-
-     This functionality can be useful if a web application shows a directory
-     listing to highlight a file opened through a file picker in that directory listing.
 </div>
 
 <div class=example id=filesystemdirectoryhandle-resolve-example>
@@ -615,17 +612,13 @@ these steps:
 const dir_ref = current_project_dir;
 if (!dir_ref) return;
 
-// Now get a file reference by showing a file picker:
-const file_ref = await self.showOpenFilePicker();
-if (!file_ref) {
-    // User cancelled, or otherwise failed to open a file.
-    return;
-}
+// Now get a file reference:
+const file_ref = await dir_ref.getFileHandle(filename, { create: true });
 
 // Check if file_ref exists inside dir_ref:
 const relative_path = await dir_ref.resolve(file_ref);
 if (relative_path === null) {
-    // Not inside dir_ref
+    // Not inside dir_ref.
 } else {
     // relative_path is an array of names, giving the relative path
     // from dir_ref to the file that is represented by file_ref:


### PR DESCRIPTION
Addresses https://github.com/whatwg/fs/issues/22

`showOpenFilePicker()` is only available in the non-standard portion of the API


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/29.html" title="Last updated on May 24, 2022, 12:29 AM UTC (efbd58c)">Preview</a> | <a href="https://whatpr.org/fs/29/464b505...efbd58c.html" title="Last updated on May 24, 2022, 12:29 AM UTC (efbd58c)">Diff</a>