### PR TITLE
Make explicit that FileSystemHandle entries map to paths

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -111,8 +111,9 @@ is left up to individual user-agent implementations.
 An [=/entry=] |a| is <dfn for="entry">the same as</dfn> an [=/entry=] |b| if |a| is equal to |b|, or
 if |a| and |b| are backed by the same file or directory on the local file system.
 
-Issue: TODO: Explain better how entries map to files on disk (multiple entries can map to the same file or
-directory on disk but an entry doesn't have to map to any file on disk).
+An [=/entry=] maps roughly to a path, but there is no guarantee this path exists on disk.
+For example, an [=/entry=] mapping to a path in the [=origin private file system=] will map to a path which
+no longer exists if site data is cleared.
 
 <div algorithm>
 To <dfn for="entry">resolve</dfn> an [=/entry=] |child| relative to a [=directory entry=] |root|,


### PR DESCRIPTION
Be more explicit in describing how FileSystemHandles map to a path on disk, and the implications of this choice. Consider the following cases:

### Clearing site data
```
// Create file at /dir/file.txt.
const dir_entry = root.getDirectoryHandle('dir', { create: true });
const file_entry = dir_entry.getFileHandle('file.txt', { create: true });

// ======== Clear site data, clearing all data in the OPFS. ========

// file_entry still points to /dir/file.txt. The promise rejects with NotFoundError.
await dir_entry.getFile();

// Re-create the directory in the fresh OPFS.
const dir_entry = root.getDirectoryHandle('dir', { create: true });

// file_entry may be able to write /dir/file.txt, despite the file not being explicitly created
// Whether this works may depend on the user agent's implementation?
await file_entry.createWritable();
```

### Moving a file handle (see https://github.com/whatwg/fs/pull/10)
```
// Create file at /old/file.txt.
const dir_entry = root.getDirectoryHandle('old', { create: true });
const file_entry = dir_entry.getFileHandle('file.txt', { create: true });

// The file previously pointed to file at /new/file.txt now resides at /old/file.txt.
await dir_entry.move('new');

// file_entry still points to /old/file.txt. The promise rejects with NotFoundError.
await dir_entry.getFile();

// Restore the directory name. file_entry once again points to a valid path.
await dir_entry.move('old');

// file_entry still points to /old/file.txt. This call should succeed.
await file_entry.getFile();
```

### Removing a file handle (see https://github.com/whatwg/fs/pull/9)
```
// Create file at /old/file.txt.
const dir_entry = root.getDirectoryHandle('old', { create: true });
const file_entry = dir_entry.getFileHandle('file.txt', { create: true });

// Remove the file.
await file_entry.remove();

// We can still write to a removed file.
await file_entry.createWritable();
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/30.html" title="Last updated on May 26, 2022, 9:06 PM UTC (f55bd64)">Preview</a> | <a href="https://whatpr.org/fs/30/464b505...f55bd64.html" title="Last updated on May 26, 2022, 9:06 PM UTC (f55bd64)">Diff</a>