### PR TITLE
Fix IDL type conversion reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -836,7 +836,7 @@ The <dfn>write a chunk</dfn> algorithm,
 given a {{FileSystemWritableFileStream}} |stream| and |chunk|,
 runs these steps:
 
-1. Let |input| be the result of [=converting=] |chunk| to a {{FileSystemWriteChunkType}}.
+1. Let |input| be the result of [=converted to an IDL value|converting=] |chunk| to a {{FileSystemWriteChunkType}}.
    If this throws an exception, then return [=a promise rejected with=] that exception.
 1. Let |p| be [=a new promise=].
 1. Run the following steps [=in parallel=]:


### PR DESCRIPTION
Fixes #48.

<!--
Thank you for contributing to the File System Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/58.html" title="Last updated on Oct 5, 2022, 11:29 AM UTC (9638b58)">Preview</a> | <a href="https://whatpr.org/fs/58/4785589...9638b58.html" title="Last updated on Oct 5, 2022, 11:29 AM UTC (9638b58)">Diff</a>