### PR TITLE
Fix typo in async iterator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -454,7 +454,7 @@ support for example recursive iteration.
 
 <div algorithm="iterator initialization">
 The [=asynchronous iterator initialization steps=] for a {{FileSystemDirectoryHandle}} |handle|
-ant its async iterator |iterator| are:
+and its async iterator |iterator| are:
 
 1. Let |access| be the result of running |handle|'s [=FileSystemHandle/entry=]'s
    [=entry/query access=] given "`read`".


### PR DESCRIPTION
Editorial change


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/67.html" title="Last updated on Oct 27, 2022, 5:20 PM UTC (590d66a)">Preview</a> | <a href="https://whatpr.org/fs/67/d64f799...590d66a.html" title="Last updated on Oct 27, 2022, 5:20 PM UTC (590d66a)">Diff</a>