### PR TITLE
Editorial: Change exceptions to be more precise

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -229,12 +229,11 @@ Their [=deserialization steps=], given |serialized| and |value| are:
   :: Returns the [=entry/name=] of the entry represented by |handle|.
 </div>
 
-The <dfn attribute for=FileSystemHandle>kind</dfn> attribute must
-return {{FileSystemHandleKind/"file"}} if the associated [=FileSystemHandle/entry=] is a [=file entry=],
+The <dfn attribute for=FileSystemHandle>kind</dfn> getter steps are to
+return {{FileSystemHandleKind/"file"}} if this is a [=file entry=],
 and return {{FileSystemHandleKind/"directory"}} otherwise.
 
-The <dfn attribute for=FileSystemHandle>name</dfn> attribute must return the [=entry/name=] of the
-associated [=FileSystemHandle/entry=].
+The <dfn attribute for=FileSystemHandle>name</dfn> getter steps are to return the [=entry/name=] of this.
 
 ### The {{FileSystemHandle/isSameEntry()}} method ### {#api-filesystemhandle-issameentry}
 
@@ -299,9 +298,9 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method steps are:
   1. Let |f| be a new {{File}}.
   1. Set |f|'s <a spec=FileAPI>snapshot state</a> to the current state of |entry|.
   1. Set |f|'s underlying byte sequence to a copy of |entry|'s [=binary data=].
-  1. Initialize the value of |f|'s {{File/name}} attribute to |entry|'s [=entry/name=].
-  1. Initialize the value of |f|'s {{File/lastModified}} attribute to |entry|'s [=file entry/modification timestamp=].
-  1. Initialize the value of |f|'s {{Blob/type}} attribute to an [=implementation-defined=] value, based on for example |entry|'s [=entry/name=] or its file extension.
+  1. Set |f|.{{File/name}} to |entry|'s [=entry/name=].
+  1. Set |f|.{{File/lastModified}} to |entry|'s [=file entry/modification timestamp=].
+  1. Set |f|.{{Blob/type}} to an [=implementation-defined=] value, based on for example |entry|'s [=entry/name=] or its file extension.
 
      Issue: The reading and snapshotting behavior needs to be better specified in the [[FILE-API]] spec,
      for now this is kind of hand-wavy.

--- a/index.bs
+++ b/index.bs
@@ -654,7 +654,7 @@ The <dfn method for=FileSystemDirectoryHandle>removeEntry(|name|, |options|)</df
      [=entry/request access=] given "`readwrite`".
      If that throws an exception, [=reject=] |result| with that exception and abort.
   1. If |access| is not "{{PermissionState/granted}}",
-     reject |result| with a "{{NotAllowedError}}"" {{DOMException}} and abort.
+     reject |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
 
   1. [=set/For each=] |child| of |entry|'s [=directory entry/children=]:
     1. If |child|'s [=entry/name=] equals |name|:

--- a/index.bs
+++ b/index.bs
@@ -94,7 +94,7 @@ and a <dfn for="file entry">shared lock count</dfn> (a number representing the n
 
 <div algorithm>
 To <dfn for="file entry/lock">take</dfn> a [=file entry/lock=] with a |value| of "`exclusive`" or "`shared`" on a given [=file entry=] |file|,
-run the following steps:
+run these steps:
 
 1. Let |lock| be the |file|'s [=file entry/lock=].
 1. Let |count| be the |file|'s [=file entry/shared lock count=].
@@ -116,7 +116,7 @@ run the following steps:
 
 <div algorithm>
 To <dfn for="file entry/lock">release</dfn> a [=file entry/lock=] on a given [=file entry=] |file|,
-run the following steps:
+run these steps:
 
 1. Let |lock| be the |file|'s associated [=file entry/lock=].
 1. Let |count| be the |file|'s [=file entry/shared lock count=].
@@ -156,10 +156,10 @@ directory on disk but an entry doesn't have to map to any file on disk).
 
 <div algorithm>
 To <dfn for="entry">resolve</dfn> an [=/entry=] |child| relative to a [=directory entry=] |root|,
-run the following steps:
+run these steps:
 
 1. Let |result| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
+1. Run these steps [=in parallel=]:
   1. If |child| is [=the same as=] |root|,
      [=/resolve=] |result| with an empty list, and abort.
   1. Let |childPromises| be « ».
@@ -170,7 +170,7 @@ run the following steps:
       1. If |path| is not null:
         1. [=list/Prepend=] |entry|'s [=entry/name=] to |path|.
         1. [=/Resolve=] |result| with |path|.
-  1. [=Wait for all=] |childPromises|, with the following success steps:
+  1. [=Wait for all=] |childPromises|, with the these success steps:
     1. If |result| hasn't been resolved yet, [=/resolve=] |result| with `null`.
 1. Return |result|.
 
@@ -247,7 +247,7 @@ The <dfn method for=FileSystemHandle>isSameEntry(|other|)</dfn> method steps are
 
 1. Let |realm| be [=this=]'s [=relevant Realm=].
 1. Let |p| be [=a new promise=] in |realm|.
-1. Run the following steps [=in parallel=]:
+1. Run these steps [=in parallel=]:
   1. If [=this=]'s [=FileSystemHandle/entry=] is [=the same as=] |other|'s [=FileSystemHandle/entry=],
      [=/resolve=] |p| with true.
   1. Otherwise [=/resolve=] |p| with false.
@@ -289,7 +289,7 @@ A {{FileSystemFileHandle}}'s associated [=FileSystemHandle/entry=] must be a [=f
 The <dfn method for=FileSystemFileHandle>getFile()</dfn> method steps are:
 
 1. Let |result| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
+1. Run these steps [=in parallel=]:
   1. Let |access| be the result of running [=this=]'s [=FileSystemHandle/entry=]'s
      [=entry/query access=] given "`read`".
   1. If |access| is not "{{PermissionState/granted}}",
@@ -343,7 +343,7 @@ modifications to existing large files.
 The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method steps are:
 
 1. Let |result| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
+1. Run these steps [=in parallel=]:
   1. Let |access| be the result of running [=this=]'s [=FileSystemHandle/entry=]'s
      [=entry/request access=] given "`readwrite`".
      If that throws an exception, [=reject=] |result| with that exception and abort.
@@ -385,7 +385,7 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method 
 The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method steps are:
 
 1. Let |result| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
+1. Run these steps [=in parallel=]:
   1. Let |access| be the result of running [=this=]'s [=FileSystemHandle/entry=]'s
      [=entry/request access=] given "`readwrite`".
      If that throws an exception, [=reject=] |result| with that exception and abort.
@@ -528,7 +528,7 @@ and its async iterator |iterator|:
 The <dfn method for=FileSystemDirectoryHandle>getFileHandle(|name|, |options|)</dfn> method steps are:
 
 1. Let |result| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
+1. Run these steps [=in parallel=]:
   1. If |name| is not a [=valid file name=], [=/reject=] |result| with a {{TypeError}} and abort.
 
   1. Let |entry| be [=this=]'s [=FileSystemHandle/entry=].
@@ -589,7 +589,7 @@ The <dfn method for=FileSystemDirectoryHandle>getFileHandle(|name|, |options|)</
 The <dfn method for=FileSystemDirectoryHandle>getDirectoryHandle(|name|, |options|)</dfn> method steps are:
 
 1. Let |result| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
+1. Run these steps [=in parallel=]:
   1. If |name| is not a [=valid file name=], [=/reject=] |result| with a {{TypeError}} and abort.
 
   1. Let |entry| be [=this=]'s [=FileSystemHandle/entry=].
@@ -647,7 +647,7 @@ The <dfn method for=FileSystemDirectoryHandle>getDirectoryHandle(|name|, |option
 The <dfn method for=FileSystemDirectoryHandle>removeEntry(|name|, |options|)</dfn> method steps are:
 
 1. Let |result| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
+1. Run these steps [=in parallel=]:
   1. If |name| is not a [=valid file name=], [=/reject=] |result| with a {{TypeError}} and abort.
 
   1. Let |entry| be [=this=]'s [=FileSystemHandle/entry=].
@@ -787,19 +787,19 @@ Similarly, when piping a {{ReadableStream}} into a {{FileSystemWritableFileStrea
 
 <div algorithm>
 To <dfn>create a new FileSystemWritableFileStream</dfn> given a [=file entry=] |file|
-in a [=/Realm=] |realm|, perform the following steps:
+in a [=/Realm=] |realm|, run these steps:
 
 1. Let |stream| be a [=new=] {{FileSystemWritableFileStream}} in |realm|.
 1. Set |stream|.[=FileSystemWritableFileStream/[[file]]=] to |file|.
 1. Let |writeAlgorithm| be an algorithm which takes a |chunk| argument
    and returns the result of running the [=write a chunk=] algorithm with |stream| and |chunk|.
-1. Let |closeAlgorithm| be the following steps:
+1. Let |closeAlgorithm| be these steps:
    1. Let |closeResult| be [=a new promise=].
-   1. Run the following steps [=in parallel=]:
+   1. Run these steps [=in parallel=]:
       1. Let |access| be the result of running |file|'s [=entry/query access=] given "`readwrite`".
       1. If |access| is not "{{PermissionState/granted}}",
          reject |closeResult| with a {{NotAllowedError}} and abort.
-      1. Perform [=implementation-defined=] malware scans and safe browsing checks.
+      1. Run [=implementation-defined=] malware scans and safe browsing checks.
          If these checks fail, [=/reject=] |closeResult| with an {{AbortError}} and abort.
       1. Set |stream|.[=FileSystemWritableFileStream/[[file]]=]'s [=file entry/binary data=] to |stream|.[=[[buffer]]=].
          If that throws an exception, [=/reject=] |closeResult| with that exception and abort.
@@ -810,7 +810,7 @@ in a [=/Realm=] |realm|, perform the following steps:
       1. [=file entry/lock/release|Release the lock=] on |stream|.[=FileSystemWritableFileStream/[[file]]=].
       1. [=/Resolve=] |closeResult| with `undefined`.
    1. Return |closeResult|.
-1. Let |abortAlgorithm| be the following step:
+1. Let |abortAlgorithm| be these steps:
       1. [=file entry/lock/release|Release the lock=] on |stream|.[=FileSystemWritableFileStream/[[file]]=].
 1. Let |highWaterMark| be 1.
 1. Let |sizeAlgorithm| be an algorithm that returns `1`.
@@ -832,7 +832,7 @@ runs these steps:
 1. Let |input| be the result of [=converted to an IDL value|converting=] |chunk| to a {{FileSystemWriteChunkType}}.
    If this throws an exception, then return [=a promise rejected with=] that exception.
 1. Let |p| be [=a new promise=].
-1. Run the following steps [=in parallel=]:
+1. Run these steps [=in parallel=]:
    1. Let |access| be the result of running |stream|'s [=FileSystemWritableFileStream/[[file]]=]'s
       [=entry/query access=] given "`readwrite`".
    1. If |access| is not "{{PermissionState/granted}}",
@@ -1047,7 +1047,7 @@ contexts where asynchronous operations come with high overhead, e.g., WebAssembl
 
 <div algorithm>
 To <dfn>create a new FileSystemSyncAccessHandle</dfn> given a [=file entry=] |file|
-in a [=/Realm=] |realm|, perform the following steps:
+in a [=/Realm=] |realm|, run these steps:
 
 1. Let |handle| be a [=new=] {{FileSystemSyncAccessHandle}} in |realm|.
 1. Set |handle|.[=FileSystemSyncAccessHandle/[[file]]=] to |file|.

--- a/index.bs
+++ b/index.bs
@@ -293,7 +293,7 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method steps are:
   1. Let |access| be the result of running [=this=]'s [=FileSystemHandle/entry=]'s
      [=entry/query access=] given "`read`".
   1. If |access| is not "{{PermissionState/granted}}",
-     reject |result| with a {{NotAllowedError}} and abort.
+     reject |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
   1. Let |entry| be [=this=]'s [=FileSystemHandle/entry=].
   1. Let |f| be a new {{File}}.
   1. Set |f|'s <a spec=FileAPI>snapshot state</a> to the current state of |entry|.
@@ -348,10 +348,10 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method 
      [=entry/request access=] given "`readwrite`".
      If that throws an exception, [=reject=] |result| with that exception and abort.
   1. If |access| is not "{{PermissionState/granted}}",
-     reject |result| with a {{NotAllowedError}} and abort.
+     reject |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
   1. Let |entry| be [=this=]'s [=FileSystemHandle/entry=].
   1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with "`shared`" on |entry|.
-  1. If |lockResult| is false, [=reject=] |result| with a {{NoModificationAllowedError}} and abort.
+  1. If |lockResult| is false, [=reject=] |result| with a "{{NoModificationAllowedError}}" {{DOMException}} and abort.
   1. Let |stream| be the result of [=create a new FileSystemWritableFileStream|creating a new FileSystemWritableFileStream=]
      for |entry| in [=this=]'s [=relevant realm=].
   1. If |options|.{{FileSystemCreateWritableOptions/keepExistingData}} is true:
@@ -390,12 +390,12 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method s
      [=entry/request access=] given "`readwrite`".
      If that throws an exception, [=reject=] |result| with that exception and abort.
   1. If |access| is not "{{PermissionState/granted}}",
-     reject |result| with a {{NotAllowedError}} and abort.
+     reject |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
   1. Let |entry| be [=this=]'s [=FileSystemHandle/entry=].
   1. If |entry| does not represent an [=/entry=] in an [=origin private file system=],
-     reject |result| with an {{InvalidStateError}} and abort.
+     reject |result| with an "{{InvalidStateError}}" {{DOMException}} and abort.
   1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with "`exclusive`" on |entry|.
-  1. If |lockResult| is false, [=reject=] |result| with a {{NoModificationAllowedError}} and abort.
+  1. If |lockResult| is false, [=reject=] |result| with a "{{NoModificationAllowedError}}" {{DOMException}} and abort.
   1. Let |handle| be the result of [=create a new FileSystemSyncAccessHandle|creating a new FileSystemSyncAccessHandle=]
      for |entry| in [=this=]'s [=relevant realm=].
   1. [=/Resolve=] |result| with |handle|.
@@ -477,7 +477,7 @@ and its async iterator |iterator|:
    [=entry/query access=] given "`read`".
 
 1. If |access| is not "{{PermissionState/granted}}",
-   reject |promise| with a {{NotAllowedError}} and return |promise|.
+   reject |promise| with a "{{NotAllowedError}}" {{DOMException}} and return |promise|.
 
 1. Let |child| be an [=/entry=] in |directory|'s [=directory entry/children=],
    such that |child|'s [=entry/name=] is not contained in |iterator|'s [=past results=],
@@ -540,15 +540,15 @@ The <dfn method for=FileSystemDirectoryHandle>getFileHandle(|name|, |options|)</
     1. Let |access| be the result of running [=this=]'s [=FileSystemHandle/entry=]'s
        [=entry/query access=] given "`read`".
   1. If |access| is not "{{PermissionState/granted}}",
-     reject |result| with a {{NotAllowedError}} and abort.
+     reject |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
 
   1. [=set/For each=] |child| of |entry|'s [=directory entry/children=]:
     1. If |child|'s [=entry/name=] equals |name|:
       1. If |child| is a [=directory entry=]:
-        1. [=/Reject=] |result| with a {{TypeMismatchError}} and abort.
+        1. [=/Reject=] |result| with a "{{TypeMismatchError}}" {{DOMException}} and abort.
       1. [=/Resolve=] |result| with a new {{FileSystemFileHandle}} whose [=FileSystemHandle/entry=] is |child| and abort.
   1. If |options|.{{FileSystemGetFileOptions/create}} is false:
-    1. [=/Reject=] |result| with a {{NotFoundError}} and abort.
+    1. [=/Reject=] |result| with a "{{NotFoundError}}" {{DOMException}} and abort.
   1. Let |child| be a new [=file entry=] whose [=query access=] and [=request access=] algorithms
      are those of |entry|.
   1. Set |child|'s [=entry/name=] to |name|.
@@ -601,15 +601,15 @@ The <dfn method for=FileSystemDirectoryHandle>getDirectoryHandle(|name|, |option
     1. Let |access| be the result of running [=this=]'s [=FileSystemHandle/entry=]'s
        [=entry/query access=] given "`read`".
   1. If |access| is not "{{PermissionState/granted}}",
-     reject |result| with a {{NotAllowedError}} and abort.
+     reject |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
 
   1. [=set/For each=] |child| of |entry|'s [=directory entry/children=]:
     1. If |child|'s [=entry/name=] equals |name|:
       1. If |child| is a [=file entry=]:
-        1. [=/Reject=] |result| with a {{TypeMismatchError}} and abort.
+        1. [=/Reject=] |result| with a "{{TypeMismatchError}}" {{DOMException}} and abort.
       1. [=/Resolve=] |result| with a new {{FileSystemDirectoryHandle}} whose [=FileSystemHandle/entry=] is |child| and abort.
   1. If |options|.{{FileSystemGetFileOptions/create}} is false:
-    1. [=/Reject=] |result| with a {{NotFoundError}} and abort.
+    1. [=/Reject=] |result| with a "{{NotFoundError}}" {{DOMException}} and abort.
   1. Let |child| be a new [=directory entry=] whose [=query access=] and [=request access=]
      algorithms are those of |entry|.
   1. Set |child|'s [=entry/name=] to |name|.
@@ -655,13 +655,13 @@ The <dfn method for=FileSystemDirectoryHandle>removeEntry(|name|, |options|)</df
      [=entry/request access=] given "`readwrite`".
      If that throws an exception, [=reject=] |result| with that exception and abort.
   1. If |access| is not "{{PermissionState/granted}}",
-     reject |result| with a {{NotAllowedError}} and abort.
+     reject |result| with a "{{NotAllowedError}}"" {{DOMException}} and abort.
 
   1. [=set/For each=] |child| of |entry|'s [=directory entry/children=]:
     1. If |child|'s [=entry/name=] equals |name|:
       1. If |child| is a [=directory entry=]:
         1. If |child|'s [=directory entry/children=] is not [=set/is empty|empty=] and |options|.{{FileSystemRemoveOptions/recursive}} is false:
-          1. [=/Reject=] |result| with an {{InvalidModificationError}} and abort.
+          1. [=/Reject=] |result| with an "{{InvalidModificationError}}" {{DOMException}} and abort.
       1. [=set/Remove=] |child| from |entry|'s [=directory entry/children=].
       1. If removing |child| in the underlying file system throws an exception,
          [=/reject=] |result| with that exception and abort.
@@ -798,9 +798,9 @@ in a [=/Realm=] |realm|, run these steps:
    1. Run these steps [=in parallel=]:
       1. Let |access| be the result of running |file|'s [=entry/query access=] given "`readwrite`".
       1. If |access| is not "{{PermissionState/granted}}",
-         reject |closeResult| with a {{NotAllowedError}} and abort.
+         reject |closeResult| with a "{{NotAllowedError}}" {{DOMException}} and abort.
       1. Run [=implementation-defined=] malware scans and safe browsing checks.
-         If these checks fail, [=/reject=] |closeResult| with an {{AbortError}} and abort.
+         If these checks fail, [=/reject=] |closeResult| with an "{{AbortError}}" {{DOMException}} and abort.
       1. Set |stream|.[=FileSystemWritableFileStream/[[file]]=]'s [=file entry/binary data=] to |stream|.[=[[buffer]]=].
          If that throws an exception, [=/reject=] |closeResult| with that exception and abort.
 
@@ -836,7 +836,7 @@ runs these steps:
    1. Let |access| be the result of running |stream|'s [=FileSystemWritableFileStream/[[file]]=]'s
       [=entry/query access=] given "`readwrite`".
    1. If |access| is not "{{PermissionState/granted}}",
-      reject |p| with a {{NotAllowedError}} and abort.
+      reject |p| with a "{{NotAllowedError}}" {{DOMException}} and abort.
    1. Let |command| be |input|.{{WriteParams/type}} if |input| is a {{WriteParams}},
       and {{WriteCommandType/"write"}} otherwise.
    1. If |command| is {{WriteCommandType/"write"}}:
@@ -872,7 +872,7 @@ runs these steps:
             |oldSize| - (|writePosition| + |data|.[=byte sequence/length=]) bytes of |stream|.[=[[buffer]]=].
       1. Set |stream|.[=[[buffer]]=] to the concatenation of |head|, |data| and |tail|.
       1. If the operations modifying |stream|.[=[[buffer]]=] in the previous steps failed
-         due to exceeding the [=storage quota=], [=/reject=] |p| with a {{QuotaExceededError}} and abort,
+         due to exceeding the [=storage quota=], [=/reject=] |p| with a "{{QuotaExceededError}}" {{DOMException}} and abort,
          leaving |stream|.[=[[buffer]]=] unmodified.
 
          Note: [=Storage quota=] only applies to files stored in the [=origin private file system=].
@@ -894,7 +894,7 @@ runs these steps:
          1. Set |stream|.[=[[buffer]]=] to a [=byte sequence=] formed by concating
             |stream|.[=[[buffer]]=] with a [=byte sequence=] containing |newSize|-|oldSize| `0x00` bytes.
          1. If the operation in the previous step failed due to exceeding the [=storage quota=],
-            [=/reject=] |p| with a {{QuotaExceededError}} and abort,
+            [=/reject=] |p| with a "{{QuotaExceededError}}" {{DOMException}} and abort,
             leaving |stream|.[=[[buffer]]=] unmodified.
 
             Note: [=Storage quota=] only applies to files stored in the [=origin private file system=].

--- a/index.bs
+++ b/index.bs
@@ -93,7 +93,6 @@ a <dfn for="file entry">lock</dfn> (a string that may exclusively be "`open`", "
 and a <dfn for="file entry">shared lock count</dfn> (a number representing the number shared locks that are taken at a given point in time).
 
 <div algorithm>
-
 To <dfn for="file entry/lock">take</dfn> a [=file entry/lock=] with a |value| of "`exclusive`" or "`shared`" on a given [=file entry=] |file|:
 
 1. Let |lock| be the |file|'s [=file entry/lock=].


### PR DESCRIPTION
Fixes #63

Before: {{InvalidStateError Error}}

After: "{{InvalidStateError Error}}" {{DOMException}}


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/70.html" title="Last updated on Nov 2, 2022, 7:49 AM UTC (4390bf5)">Preview</a> | <a href="https://whatpr.org/fs/70/abad896...4390bf5.html" title="Last updated on Nov 2, 2022, 7:49 AM UTC (4390bf5)">Diff</a>