### PR TITLE
Editorial: Do not render TODO(fivedots) in the spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -331,15 +331,15 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method steps are:
      {{FileSystemSyncAccessHandle|FileSystemSyncAccessHandles}} for the entry, until the stream is closed.
 </div>
 
-See <a href=...>WICG/file-system-access issue 67...</a> for discussion around
-and desire for a "inPlace" mode for createWritable (where changes will be
-written to the actual underlying file as they are written to the writer, for
-example to support in-place modification of large files or things like
-databases). This is not currently implemented in Chrome. Implementing this is
-currently blocked on figuring out how to combine the desire to run malware
+See <a href=https://github.com/WICG/file-system-access/issues/67>WICG/file-system-access issue #67</a>
+for discussion around and desire for a "inPlace" mode for createWritable (where
+changes will be written to the actual underlying file as they are written to the
+writer, for example to support in-place modification of large files or things
+like databases). This is not currently implemented in Chrome. Implementing this
+is currently blocked on figuring out how to combine the desire to run malware
 checks with the desire to let websites make fast in-place modifications to
-existing large files. In-place writes are available for files in the
-[=origin private file system=] via the {{FileSystemSyncAccessHandle}} interface.
+existing large files. In-place writes are available for files in the [=origin
+private file system=] via the {{FileSystemSyncAccessHandle}} interface.
 
 <div algorithm>
 The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method steps are:

--- a/index.bs
+++ b/index.bs
@@ -150,7 +150,7 @@ is left up to individual user-agent implementations.
 An [=/entry=] |a| is <dfn for="entry">the same as</dfn> an [=/entry=] |b| if |a| is equal to |b|, or
 if |a| and |b| are backed by the same file or directory on the local file system.
 
-Issue: TODO: Explain better how entries map to files on disk (multiple entries can map to the same file or
+Issue(59): Explain better how entries map to files on disk (multiple entries can map to the same file or
 directory on disk but an entry doesn't have to map to any file on disk).
 
 <div algorithm>
@@ -1063,7 +1063,8 @@ in a [=/Realm=] |realm|, run these steps:
   :: Reads the contents of the file associated with |handle| into |buffer|, optionally at a given offset.
 </div>
 
-// TODO(fivedots): Specify how Access Handles should react when reading from a file that has been modified externally.
+Issue(35): Specify how Access Handles should react when reading from a file that has been modified externally.
+
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWriteOptions}}: |options|)</dfn> method steps are:
 
@@ -1096,7 +1097,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
      Checking the returned number of written bytes allows callers to detect and handle errors and partial writes.
 </div>
 
-// TODO(fivedots): Figure out how to properly check the available storage quota (in this method and others) by passing the right storage shelf.
+<!-- TODO(fivedots): Figure out how to properly check the available storage quota (in this method and others) by passing the right storage shelf. -->
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadWriteOptions}}: |options|)</dfn> method steps are:
 
@@ -1190,7 +1191,7 @@ The <dfn method for=FileSystemSyncAccessHandle>getSize()</dfn> method steps are:
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>flush()</dfn> method steps are:
 
-// TODO(fivedots): Fill in, after figuring out language to describe flushing at the OS level.
+Issue(71): Fill in, after figuring out language to describe flushing at the OS level.
 
 </div>
 
@@ -1202,10 +1203,11 @@ The <dfn method for=FileSystemSyncAccessHandle>flush()</dfn> method steps are:
      [=file entry/lock/release|releases the lock=] on the [=FileSystemHandle/entry=] associated with |handle|.
 </div>
 
-//TODO(fivedots): Figure out language to describe flushing the file at the OS level before closing the handle.
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>close()</dfn> method steps are
 to set [=this=].[=[[state]]=] to "`closed`".
+
+Issue(71): Figure out language to describe flushing the file at the OS level before closing the handle.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -331,12 +331,15 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method steps are:
      {{FileSystemSyncAccessHandle|FileSystemSyncAccessHandles}} for the entry, until the stream is closed.
 </div>
 
-Issue(67): There has been some discussion around and desire for a "inPlace" mode for createWritable
-(where changes will be written to the actual underlying file as they are written to the writer, for
-example to support in-place modification of large files or things like databases). This is not
-currently implemented in Chrome. Implementing this is currently blocked on figuring out how to
-combine the desire to run malware checks with the desire to let websites make fast in-place
-modifications to existing large files.
+See <a href=...>WICG/file-system-access issue 67...</a> for discussion around
+and desire for a "inPlace" mode for createWritable (where changes will be
+written to the actual underlying file as they are written to the writer, for
+example to support in-place modification of large files or things like
+databases). This is not currently implemented in Chrome. Implementing this is
+currently blocked on figuring out how to combine the desire to run malware
+checks with the desire to let websites make fast in-place modifications to
+existing large files. In-place writes are available for files in the
+[=origin private file system=] via the {{FileSystemSyncAccessHandle}} interface.
 
 <div algorithm>
 The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method steps are:
@@ -447,7 +450,7 @@ A {{FileSystemDirectoryHandle}}'s associated [=FileSystemHandle/entry=] must be 
      No guarantees are given either way.
 </div>
 
-Issue(173): In the future we might want to add arguments to the async iterable declaration to
+Issue(15): In the future we might want to add arguments to the async iterable declaration to
 support for example recursive iteration.
 
 <div algorithm="iterator initialization">
@@ -557,7 +560,7 @@ The <dfn method for=FileSystemDirectoryHandle>getFileHandle(|name|, |options|)</
   1. If creating |child| in the underlying file system throws an exception,
      [=/reject=] |result| with that exception and abort.
 
-     Issue(68): Better specify what possible exceptions this could throw.
+     Issue(11): Better specify what possible exceptions this could throw.
   1. [=/Resolve=] |result| with a new {{FileSystemFileHandle}} whose [=FileSystemHandle/entry=] is |child|.
 1. Return |result|.
 
@@ -617,7 +620,7 @@ The <dfn method for=FileSystemDirectoryHandle>getDirectoryHandle(|name|, |option
   1. If creating |child| in the underlying file system throws an exception,
      [=/reject=] |result| with that exception and abort.
 
-     Issue(68): Better specify what possible exceptions this could throw.
+     Issue(11): Better specify what possible exceptions this could throw.
   1. [=/Resolve=] |result| with a new {{FileSystemDirectoryHandle}} whose [=FileSystemHandle/entry=] is |child|.
 1. Return |result|.
 
@@ -669,7 +672,7 @@ The <dfn method for=FileSystemDirectoryHandle>removeEntry(|name|, |options|)</df
          non-atomically. Some files or directories might have been removed while other files
          or directories still exist.
 
-         Issue(68): Better specify what possible exceptions this could throw.
+         Issue(11): Better specify what possible exceptions this could throw.
       1. [=/Resolve=] |result| with `undefined`.
   1. [=/Reject=] |result| with a {{NotFoundError}}.
 1. Return |result|.

--- a/index.bs
+++ b/index.bs
@@ -331,7 +331,7 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method steps are:
      {{FileSystemSyncAccessHandle|FileSystemSyncAccessHandles}} for the entry, until the stream is closed.
 </div>
 
-See <a href=https://github.com/WICG/file-system-access/issues/67>WICG/file-system-access issue #67</a>
+<p class=XXX>See <a href=https://github.com/WICG/file-system-access/issues/67>WICG/file-system-access issue #67</a>
 for discussion around and desire for a "inPlace" mode for createWritable (where
 changes will be written to the actual underlying file as they are written to the
 writer, for example to support in-place modification of large files or things


### PR DESCRIPTION
Fixes #66.

Updates some TODOs to reference a corresponding issue while turning others into HTML comments so they do not render as part of the spec


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/72.html" title="Last updated on Nov 9, 2022, 5:04 PM UTC (7468203)">Preview</a> | <a href="https://whatpr.org/fs/72/abad896...7468203.html" title="Last updated on Nov 9, 2022, 5:04 PM UTC (7468203)">Diff</a>