### PR TITLE
Require an exclusive lock in removeEntry()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -656,6 +656,11 @@ The <dfn method for=FileSystemDirectoryHandle>removeEntry(|name|, |options|)</df
   1. If |access| is not "{{PermissionState/granted}}",
      reject |result| with a {{NotAllowedError}} and abort.
 
+  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
+     with "`exclusive`" on |entry|.
+  1. If |lockResult| is false, [=reject=] |result| with a
+     "{{NoModificationAllowedError}}" {{DOMException}} and abort.
+
   1. [=set/For each=] |child| of |entry|'s [=directory entry/children=]:
     1. If |child|'s [=entry/name=] equals |name|:
       1. If |child| is a [=directory entry=]:


### PR DESCRIPTION
<!--
Thank you for contributing to the File System Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

For the sake of backwards compatibility, `removeEntry()` currently only requires acquiring a shared lock in Chromium (though this is not specified). This means that you cannot remove a file with an open Access Handle, but you _can_ remove a file with an open `WritableFileStream`.

The `removeEntry()` method should take an exclusive lock, matching #9. At least until we change the locking paradigm to not be based on "exclusive" and "shared" locks in #34.

- [ ] At least two implementers are interested (and none opposed):
   * All implementers have expressed support that this should match `remove()` in https://github.com/whatwg/fs/issues/34
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/1254078
   * Gecko: …
   * WebKit: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
