### PR TITLE
Editorial: Export "file system entry/parent" term needed by the WICG spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -132,7 +132,8 @@ A <dfn export id=directory>directory entry</dfn> additionally consists of a [=/s
 Each member is either a [=/file entry=] or a [=/directory entry=].
 
 A [=/file system entry=] |entry| should be [=list/contained=] in the [=children=] of at most one
-[=directory entry=], and that directory entry is also known as |entry|'s <dfn for="file system entry" id=entry-parent>parent</dfn>.
+[=directory entry=], and that directory entry is also known as |entry|'s
+<dfn export for="file system entry" id=entry-parent>parent</dfn>.
 A [=/file system entry=]'s [=file system entry/parent=] is null if no such directory entry exists.
 
 Note: Two different [=/file system entries=] can represent the same file or directory on disk, in which


### PR DESCRIPTION
This was missed in #8. This will allow https://github.com/WICG/file-system-access/pull/392 to land


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/75.html" title="Last updated on Nov 17, 2022, 6:52 PM UTC (149aa5a)">Preview</a> | <a href="https://whatpr.org/fs/75/392116b...149aa5a.html" title="Last updated on Nov 17, 2022, 6:52 PM UTC (149aa5a)">Diff</a>