### PR TITLE
Cursor support for FileSystemSyncAccessHandle

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1048,7 +1048,7 @@ as well as obtaining and changing the size of, a single file.
 A {{FileSystemSyncAccessHandle}} offers synchronous methods. This allows for higher performance on
 contexts where asynchronous operations come with high overhead, e.g., WebAssembly.
 
-A {{FileSystemWritableFileStream}} has a <dfn for="FileSystemWritableFileStream">file position cursor</dfn> initialized at byte offset 0 from the top of the file.
+A {{FileSystemSyncAccessHandle}} has a <dfn for="FileSystemWritableFileStream">file position cursor</dfn> initialized at byte offset 0 from the top of the file.
 
 <div algorithm>
 To <dfn>create a new FileSystemSyncAccessHandle</dfn> given a [=file entry=] |file|
@@ -1078,9 +1078,9 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 1. Let |bufferSize| be |buffer|'s [=byte length=].
 1. Let |fileContents| be [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. Let |fileSize| be |fileContents|'s [=byte sequence/length=].
-1. Let |readStart| be |options|["{{FileSystemReadWriteOptions/at}}"], if given; otherwise [=this=]'s [=FileSystemWritableFileStream/file position cursor=].
+1. Let |readStart| be |options|["{{FileSystemReadWriteOptions/at}}"], if given; otherwise [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=].
 1. If |readStart| is larger than |fileSize|:
-    1. Set [=this=]'s [=FileSystemWritableFileStream/file position cursor=] to |fileSize|.
+    1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to |fileSize|.
     1. Return 0.
 1. Let |readEnd| be |readStart| + (|bufferSize| &minus; 1).
 1. If |readEnd| is larger than |fileSize|, set |readEnd| to |fileSize|.
@@ -1092,7 +1092,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
     1. Otherwise set |result| to 0.
 1. Let |arrayBuffer| be |buffer|'s [=underlying buffer=].
 1. [=ArrayBuffer/write|Write=] |bytes| into |arrayBuffer|.
-1. Set [=this=]'s [=FileSystemWritableFileStream/file position cursor=] to |readStart| + |result|.
+1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to |readStart| + |result|.
 1. Return |result|.
 
 </div>
@@ -1111,7 +1111,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadWriteOptions}}: |options|)</dfn> method steps are:
 
 1. If [=this=].[=[[state]]=] is "`closed`", throw an {{InvalidStateError}}.
-1. Let |writePosition| be |options|["{{FileSystemReadWriteOptions/at}}"], if given; otherwise [=this=]'s [=FileSystemWritableFileStream/file position cursor=].
+1. Let |writePosition| be |options|["{{FileSystemReadWriteOptions/at}}"], if given; otherwise [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=].
 1. Let |fileContents| be a copy of [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. Let |oldSize| be |fileContents|'s [=byte sequence/length=].
 1. Let |bufferSize| be |buffer|'s [=byte length=].
@@ -1141,10 +1141,10 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
    failed:
     1. If there were partial writes and the number of bytes that were written from |buffer| is known:
         1. Let |bytesWritten| be the number of bytes that were written from |buffer|.
-        1. Set [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be |writePosition| + |bytesWritten|.
+        1. Set [=this=]'s [= FileSystemSyncAccessHandle/file position cursor=] to be |writePosition| + |bytesWritten|.
         1. Return |bytesWritten|.
     1. Otherwise throw an {{InvalidStateError}}.
-1. Set [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be |writePosition| + |bufferSize|.
+1. Set [=this=]'s [= FileSystemSyncAccessHandle/file position cursor=] to be |writePosition| + |bufferSize|.
 1. Return |bufferSize|.
 
 </div>
@@ -1177,7 +1177,7 @@ The <dfn method for=FileSystemSyncAccessHandle>truncate(|newSize|)</dfn> method 
       in |fileContents|.
    1. If the operations modifying the [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=] in the previous steps
       failed, throw an {{InvalidStateError}}.
-1. If [=this=]'s [=FileSystemWritableFileStream/file position cursor=] is greater than |newSize|, then set [=FileSystemWritableFileStream/file position cursor=] to |newSize|.
+1. If [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] is greater than |newSize|, then set [=FileSystemSyncAccessHandle/file position cursor=] to |newSize|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1048,7 +1048,7 @@ as well as obtaining and changing the size of, a single file.
 A {{FileSystemSyncAccessHandle}} offers synchronous methods. This allows for higher performance on
 contexts where asynchronous operations come with high overhead, e.g., WebAssembly.
 
-A {{FileSystemSyncAccessHandle}} has a <dfn for="FileSystemWritableFileStream">file position cursor</dfn> initialized at byte offset 0 from the top of the file.
+A {{FileSystemSyncAccessHandle}} has a <dfn for="FileSystemSyncAccessHandle">file position cursor</dfn> initialized at byte offset 0 from the top of the file.
 
 <div algorithm>
 To <dfn>create a new FileSystemSyncAccessHandle</dfn> given a [=file entry=] |file|

--- a/index.bs
+++ b/index.bs
@@ -1282,7 +1282,7 @@ The <dfn method for=StorageManager>getDirectory()</dfn> method steps are:
 (<a href=https://www.mozilla.org/>Mozilla</a>, <a href=mailto:rjesup@mozilla.com>rjesup@mozilla.com</a>
 
 <p>This standard is written by <span lang=nl>Marijn Kruisselbrink</span>
-(<a href=https://www.google.com/>Google</a>, <a href=mailto:mek@chromium.org>mek@chromium.org</a>)).
+(<a href=https://www.google.com/>Google</a>, <a href=mailto:mek@chromium.org>mek@chromium.org</a>).
 
 
 <p boilerplate=ipr>This Living Standard includes material copied from W3C WICG's

--- a/index.bs
+++ b/index.bs
@@ -1092,7 +1092,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
     1. Otherwise set |result| to 0.
 1. Let |arrayBuffer| be |buffer|'s [=underlying buffer=].
 1. [=ArrayBuffer/write|Write=] |bytes| into |arrayBuffer|.
-1. Update [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be |readStart| + |result|.
+1. Set [=this=]'s [=FileSystemWritableFileStream/file position cursor=] to |readStart| + |result|.
 1. Return |result|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1048,7 +1048,7 @@ as well as obtaining and changing the size of, a single file.
 A {{FileSystemSyncAccessHandle}} offers synchronous methods. This allows for higher performance on
 contexts where asynchronous operations come with high overhead, e.g., WebAssembly.
 
-A {{FileSystemWritableFileStream}} has a file position cursor initialized at byte offset 0 from the top of the file.
+A {{FileSystemWritableFileStream}} has a <dfn for="FileSystemWritableFileStream">file position cursor</dfn> initialized at byte offset 0 from the top of the file.
 
 <div algorithm>
 To <dfn>create a new FileSystemSyncAccessHandle</dfn> given a [=file entry=] |file|

--- a/index.bs
+++ b/index.bs
@@ -1144,7 +1144,7 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
         1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to |writePosition| + |bytesWritten|.
         1. Return |bytesWritten|.
     1. Otherwise throw an {{InvalidStateError}}.
-1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to be |writePosition| + |bufferSize|.
+1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to |writePosition| + |bufferSize|.
 1. Return |bufferSize|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1092,7 +1092,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
     1. Otherwise set |result| to 0.
 1. Let |arrayBuffer| be |buffer|'s [=underlying buffer=].
 1. [=ArrayBuffer/write|Write=] |bytes| into |arrayBuffer|.
-1. Update the file cursor offset to be |readStart| + |result|.
+1. Update [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be |readStart| + |result|.
 1. Return |result|.
 
 </div>
@@ -1111,7 +1111,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadWriteOptions}}: |options|)</dfn> method steps are:
 
 1. If [=this=].[=[[state]]=] is "`closed`", throw an {{InvalidStateError}}.
-1. Let |writePosition| be |options|.{{FileSystemReadWriteOptions/at}}, if specified, else the current file cursor offset.
+1. Let |writePosition| be |options|.{{FileSystemReadWriteOptions/at}}, if specified, else the current file offset.
 1. Let |fileContents| be a copy of [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. Let |oldSize| be |fileContents|'s [=byte sequence/length=].
 1. Let |bufferSize| be |buffer|'s [=byte length=].
@@ -1142,7 +1142,7 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
     1. If there were partial writes and the number of bytes that were written from |buffer| is known,
        return the number of bytes that were written from |buffer|.
     1. Otherwise throw an {{InvalidStateError}}.
-1. Update the file cursor offset to be at the end of the written |buffer|.
+1. Update [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be at the end of the written |buffer|.
 1. Return |bufferSize|.
 
 </div>
@@ -1175,7 +1175,7 @@ The <dfn method for=FileSystemSyncAccessHandle>truncate(|newSize|)</dfn> method 
       in |fileContents|.
    1. If the operations modifying the [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=] in the previous steps
       failed, throw an {{InvalidStateError}}.
-1. If the current file cursor offset is greater than |newSize|, the file cursor offset is set to |newSize|.
+1. If [=this=]'s current [= FileSystemWritableFileStream/file position cursor=] is greater than |newSize|, the [= FileSystemWritableFileStream/file position cursor=] is set to |newSize|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1078,7 +1078,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 1. Let |bufferSize| be |buffer|'s [=byte length=].
 1. Let |fileContents| be [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. Let |fileSize| be |fileContents|'s [=byte sequence/length=].
-1. Let |readStart| be |options|.{{FileSystemReadWriteOptions/at}}, if specified, else the current file cursor offset.
+1. Let |readStart| be |options|.{{FileSystemReadWriteOptions/at}}, if given; otherwise [=this=]'s [= FileSystemWritableFileStream/file position cursor=].
 1. If |readStart| is larger than |fileSize|:
     1. Update the file cursor offset to be |fileSize|.
     1. Return 0.

--- a/index.bs
+++ b/index.bs
@@ -1067,7 +1067,7 @@ in a [=/Realm=] |realm|, run these steps:
   : |handle| . {{FileSystemSyncAccessHandle/read()|read}}(|buffer|)
   : |handle| . {{FileSystemSyncAccessHandle/read()|read}}(|buffer|, { {{FileSystemReadWriteOptions/at}} })
   :: Reads the contents of the file associated with |handle| into |buffer|, optionally at a given offset.
-  :: The file cursor is updated when {{read}} is called to point to the byte after the last byte read.
+  :: The file cursor is updated when {{FileSystemSyncAccessHandle/read()}} is called to point to the byte after the last byte read.
 </div>
 
 Issue(35): Specify how Access Handles should react when reading from a file that has been modified externally.

--- a/index.bs
+++ b/index.bs
@@ -1158,7 +1158,6 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
   :: Resizes the file associated with |handle| to be |newSize| bytes long. If |newSize| is larger than the current file size this pads the file with null bytes; otherwise it truncates the file.
 
   :: The file cursor is updated when {{truncate}} is called. If the cursor is smaller than |newSize|, it remains unchanged. If the cursor is larger than |newSize|, it is set to |newSize|.
-
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -1278,9 +1278,10 @@ The <dfn method for=StorageManager>getDirectory()</dfn> method steps are:
 
 
 <h2 class=no-num id="acks">Acknowledgments</h2>
+<span lang=nl>Randell Jesup</span>
+(<a href=https://www.mozilla.org/>Mozilla</a>, <a href=mailto:rjesup@mozilla.com>rjesup@mozilla.com</a>
 
-<p>This standard is written by <span lang=nl>Randell Jesup</span>
-(<a href=https://www.mozilla.org/>Mozilla</a>, <a href=mailto:rjesup@mozilla.com>rjesup@mozilla.com</a>, <span lang=nl>Marijn Kruisselbrink</span>
+<p>This standard is written by <span lang=nl>Marijn Kruisselbrink</span>
 (<a href=https://www.google.com/>Google</a>, <a href=mailto:mek@chromium.org>mek@chromium.org</a>)).
 
 

--- a/index.bs
+++ b/index.bs
@@ -1273,8 +1273,9 @@ The <dfn method for=StorageManager>getDirectory()</dfn> method steps are:
 
 <h2 class=no-num id="acks">Acknowledgments</h2>
 
-<p>This standard is written by <span lang=nl>Marijn Kruisselbrink</span>
-(<a href=https://www.google.com/>Google</a>, <a href=mailto:mek@chromium.org>mek@chromium.org</a>).
+<p>This standard is written by <span lang=nl>Randell Jesup</span>
+(<a href=https://www.mozilla.org/>Mozilla</a>, <a href=mailto:rjesup@mozilla.com>rjesup@mozilla.com</a>, <span lang=nl>Marijn Kruisselbrink</span>
+(<a href=https://www.google.com/>Google</a>, <a href=mailto:mek@chromium.org>mek@chromium.org</a>)).
 
 
 <p boilerplate=ipr>This Living Standard includes material copied from W3C WICG's

--- a/index.bs
+++ b/index.bs
@@ -1152,6 +1152,9 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
 <div class="note domintro">
   : |handle| . {{FileSystemSyncAccessHandle/truncate()|truncate}}(|newSize|)
   :: Resizes the file associated with |handle| to be |newSize| bytes long. If |newSize| is larger than the current file size this pads the file with null bytes; otherwise it truncates the file.
+
+  :: The file cursor is updated when {{truncate}} is called. If the cursor is smaller than |newSize|, it remains unchanged. If the cursor is larger than |newSize|, it is set to |newSize|.
+
 </div>
 
 <div algorithm>
@@ -1172,6 +1175,7 @@ The <dfn method for=FileSystemSyncAccessHandle>truncate(|newSize|)</dfn> method 
       in |fileContents|.
    1. If the operations modifying the [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=] in the previous steps
       failed, throw an {{InvalidStateError}}.
+1. If the current file cursor offset is greater than |newSize|, the file cursor offset is set to |newSize|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1175,7 +1175,7 @@ The <dfn method for=FileSystemSyncAccessHandle>truncate(|newSize|)</dfn> method 
       in |fileContents|.
    1. If the operations modifying the [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=] in the previous steps
       failed, throw an {{InvalidStateError}}.
-1. If [=this=]'s current [= FileSystemWritableFileStream/file position cursor=] is greater than |newSize|, the [= FileSystemWritableFileStream/file position cursor=] is set to |newSize|.
+1. If [=this=]'s [=FileSystemWritableFileStream/file position cursor=] is greater than |newSize|, then set [=FileSystemWritableFileStream/file position cursor=] to |newSize|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1078,7 +1078,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 1. Let |bufferSize| be |buffer|'s [=byte length=].
 1. Let |fileContents| be [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. Let |fileSize| be |fileContents|'s [=byte sequence/length=].
-1. Let |readStart| be |options|.{{FileSystemReadWriteOptions/at}}, if given; otherwise [=this=]'s [= FileSystemWritableFileStream/file position cursor=].
+1. Let |readStart| be |options|["{{FileSystemReadWriteOptions/at}}"], if given; otherwise [=this=]'s [=FileSystemWritableFileStream/file position cursor=].
 1. If |readStart| is larger than |fileSize|:
     1. Set [=this=]'s [=FileSystemWritableFileStream/file position cursor=] to |fileSize|.
     1. Return 0.

--- a/index.bs
+++ b/index.bs
@@ -1139,10 +1139,12 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
 
 1. If the operations modifying the [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=] in the previous steps
    failed:
-    1. If there were partial writes and the number of bytes that were written from |buffer| is known,
-       return the number of bytes that were written from |buffer|.
+    1. If there were partial writes and the number of bytes that were written from |buffer| is known:
+        1. Let |bytesWritten| be the number of bytes that were written from |buffer|.
+        1. Update [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be |writePosition| + |bytesWritten|.
+        1. Return |bytesWritten|.
     1. Otherwise throw an {{InvalidStateError}}.
-1. Update [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be at the end of the written |buffer|.
+1. Update [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be |writePosition| + |bufferSize|.
 1. Return |bufferSize|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1080,7 +1080,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 1. Let |fileSize| be |fileContents|'s [=byte sequence/length=].
 1. Let |readStart| be |options|.{{FileSystemReadWriteOptions/at}}, if given; otherwise [=this=]'s [= FileSystemWritableFileStream/file position cursor=].
 1. If |readStart| is larger than |fileSize|:
-    1. Set [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to |fileSize|.
+    1. Set [=this=]'s [=FileSystemWritableFileStream/file position cursor=] to |fileSize|.
     1. Return 0.
 1. Let |readEnd| be |readStart| + (|bufferSize| &minus; 1).
 1. If |readEnd| is larger than |fileSize|, set |readEnd| to |fileSize|.

--- a/index.bs
+++ b/index.bs
@@ -1048,6 +1048,8 @@ as well as obtaining and changing the size of, a single file.
 A {{FileSystemSyncAccessHandle}} offers synchronous methods. This allows for higher performance on
 contexts where asynchronous operations come with high overhead, e.g., WebAssembly.
 
+A {{FileSystemWritableFileStream}} has a file position cursor initialized at byte offset 0 from the top of the file.
+
 <div algorithm>
 To <dfn>create a new FileSystemSyncAccessHandle</dfn> given a [=file entry=] |file|
 in a [=/Realm=] |realm|, run these steps:
@@ -1076,8 +1078,10 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 1. Let |bufferSize| be |buffer|'s [=byte length=].
 1. Let |fileContents| be [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. Let |fileSize| be |fileContents|'s [=byte sequence/length=].
-1. Let |readStart| be |options|.{{FileSystemReadWriteOptions/at}}.
-1. If |readStart| is larger than |fileSize|, return 0.
+1. Let |readStart| be |options|.{{FileSystemReadWriteOptions/at}}, if specified, else the current file cursor offset.
+1. If |readStart| is larger than |fileSize|:
+    1. Update the file cursor offset to be |fileSize|.
+    1. Return 0.
 1. Let |readEnd| be |readStart| + (|bufferSize| &minus; 1).
 1. If |readEnd| is larger than |fileSize|, set |readEnd| to |fileSize|.
 1. Let |bytes| be a [=byte sequence=] containing the bytes from |readStart| to |readEnd| of |fileContents|.
@@ -1088,6 +1092,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
     1. Otherwise set |result| to 0.
 1. Let |arrayBuffer| be |buffer|'s [=underlying buffer=].
 1. [=ArrayBuffer/write|Write=] |bytes| into |arrayBuffer|.
+1. Update the file cursor offset to be |readStart| + |result|.
 1. Return |result|.
 
 </div>
@@ -1106,7 +1111,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadWriteOptions}}: |options|)</dfn> method steps are:
 
 1. If [=this=].[=[[state]]=] is "`closed`", throw an {{InvalidStateError}}.
-1. Let |writePosition| be |options|.{{FileSystemReadWriteOptions/at}}.
+1. Let |writePosition| be |options|.{{FileSystemReadWriteOptions/at}}, if specified, else the current file cursor offset.
 1. Let |fileContents| be a copy of [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. Let |oldSize| be |fileContents|'s [=byte sequence/length=].
 1. Let |bufferSize| be |buffer|'s [=byte length=].
@@ -1137,6 +1142,7 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
     1. If there were partial writes and the number of bytes that were written from |buffer| is known,
        return the number of bytes that were written from |buffer|.
     1. Otherwise throw an {{InvalidStateError}}.
+1. Update the file cursor offset to be at the end of the written |buffer|.
 1. Return |bufferSize|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1080,7 +1080,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 1. Let |fileSize| be |fileContents|'s [=byte sequence/length=].
 1. Let |readStart| be |options|.{{FileSystemReadWriteOptions/at}}, if given; otherwise [=this=]'s [= FileSystemWritableFileStream/file position cursor=].
 1. If |readStart| is larger than |fileSize|:
-    1. Update the file cursor offset to be |fileSize|.
+    1. Set [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to |fileSize|.
     1. Return 0.
 1. Let |readEnd| be |readStart| + (|bufferSize| &minus; 1).
 1. If |readEnd| is larger than |fileSize|, set |readEnd| to |fileSize|.

--- a/index.bs
+++ b/index.bs
@@ -1141,7 +1141,7 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
    failed:
     1. If there were partial writes and the number of bytes that were written from |buffer| is known:
         1. Let |bytesWritten| be the number of bytes that were written from |buffer|.
-        1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to be |writePosition| + |bytesWritten|.
+        1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to |writePosition| + |bytesWritten|.
         1. Return |bytesWritten|.
     1. Otherwise throw an {{InvalidStateError}}.
 1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to be |writePosition| + |bufferSize|.

--- a/index.bs
+++ b/index.bs
@@ -1141,10 +1141,10 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
    failed:
     1. If there were partial writes and the number of bytes that were written from |buffer| is known:
         1. Let |bytesWritten| be the number of bytes that were written from |buffer|.
-        1. Update [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be |writePosition| + |bytesWritten|.
+        1. Set [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be |writePosition| + |bytesWritten|.
         1. Return |bytesWritten|.
     1. Otherwise throw an {{InvalidStateError}}.
-1. Update [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be |writePosition| + |bufferSize|.
+1. Set [=this=]'s [= FileSystemWritableFileStream/file position cursor=] to be |writePosition| + |bufferSize|.
 1. Return |bufferSize|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1067,6 +1067,7 @@ in a [=/Realm=] |realm|, run these steps:
   : |handle| . {{FileSystemSyncAccessHandle/read()|read}}(|buffer|)
   : |handle| . {{FileSystemSyncAccessHandle/read()|read}}(|buffer|, { {{FileSystemReadWriteOptions/at}} })
   :: Reads the contents of the file associated with |handle| into |buffer|, optionally at a given offset.
+  :: The file cursor is updated when {{read}} is called to point to the byte after the last byte read.
 </div>
 
 Issue(35): Specify how Access Handles should react when reading from a file that has been modified externally.
@@ -1104,6 +1105,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
   : |handle| . {{FileSystemSyncAccessHandle/write()|write}}(|buffer|, { {{FileSystemReadWriteOptions/at}} })
   :: Writes the content of |buffer| into the file associated with |handle|, optionally at a given offset, and returns the number of written bytes.
      Checking the returned number of written bytes allows callers to detect and handle errors and partial writes.
+  :: The file cursor is updated when {{write}} is called to point to the byte after the last byte written.
 </div>
 
 <!-- TODO(fivedots): Figure out how to properly check the available storage quota (in this method and others) by passing the right storage shelf. -->

--- a/index.bs
+++ b/index.bs
@@ -1278,8 +1278,7 @@ The <dfn method for=StorageManager>getDirectory()</dfn> method steps are:
 
 
 <h2 class=no-num id="acks">Acknowledgments</h2>
-<span lang=nl>Randell Jesup</span>
-(<a href=https://www.mozilla.org/>Mozilla</a>, <a href=mailto:rjesup@mozilla.com>rjesup@mozilla.com</a>
+Randell Jesup
 
 <p>This standard is written by <span lang=nl>Marijn Kruisselbrink</span>
 (<a href=https://www.google.com/>Google</a>, <a href=mailto:mek@chromium.org>mek@chromium.org</a>).

--- a/index.bs
+++ b/index.bs
@@ -1278,7 +1278,6 @@ The <dfn method for=StorageManager>getDirectory()</dfn> method steps are:
 
 
 <h2 class=no-num id="acks">Acknowledgments</h2>
-Randell Jesup
 
 <p>This standard is written by <span lang=nl>Marijn Kruisselbrink</span>
 (<a href=https://www.google.com/>Google</a>, <a href=mailto:mek@chromium.org>mek@chromium.org</a>).

--- a/index.bs
+++ b/index.bs
@@ -1141,10 +1141,10 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
    failed:
     1. If there were partial writes and the number of bytes that were written from |buffer| is known:
         1. Let |bytesWritten| be the number of bytes that were written from |buffer|.
-        1. Set [=this=]'s [= FileSystemSyncAccessHandle/file position cursor=] to be |writePosition| + |bytesWritten|.
+        1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to be |writePosition| + |bytesWritten|.
         1. Return |bytesWritten|.
     1. Otherwise throw an {{InvalidStateError}}.
-1. Set [=this=]'s [= FileSystemSyncAccessHandle/file position cursor=] to be |writePosition| + |bufferSize|.
+1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to be |writePosition| + |bufferSize|.
 1. Return |bufferSize|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1111,7 +1111,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadWriteOptions}}: |options|)</dfn> method steps are:
 
 1. If [=this=].[=[[state]]=] is "`closed`", throw an {{InvalidStateError}}.
-1. Let |writePosition| be |options|.{{FileSystemReadWriteOptions/at}}, if specified, else the current file offset.
+1. Let |writePosition| be |options|["{{FileSystemReadWriteOptions/at}}"], if given; otherwise [=this=]'s [=FileSystemWritableFileStream/file position cursor=].
 1. Let |fileContents| be a copy of [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. Let |oldSize| be |fileContents|'s [=byte sequence/length=].
 1. Let |bufferSize| be |buffer|'s [=byte length=].


### PR DESCRIPTION
Adds cursor to FileSystemSyncAccessHandle, similar to the cursor for WritableFileStream.  This means that supplying an 'at:' parameter for every read and write will not be needed.

- [ ] At least two implementers are interested (and none opposed):
   * Mozilla
   * Google
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://phabricator.services.mozilla.com/D163399
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/1394790
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1803241
   * WebKit: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/76.html" title="Last updated on Dec 3, 2022, 7:49 AM UTC (e5918b1)">Preview</a> | <a href="https://whatpr.org/fs/76/ae20870...e5918b1.html" title="Last updated on Dec 3, 2022, 7:49 AM UTC (e5918b1)">Diff</a>