### PR TITLE
Throw TypeError if passed an offset not supported on the underlying OS

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1081,6 +1081,8 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 1. Let |readStart| be |options|["{{FileSystemReadWriteOptions/at}}"] if
    |options|["{{FileSystemReadWriteOptions/at}}"] [=map/exists=]; otherwise
    [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=].
+1. If the underlying file system does not support reading from a file offset of
+   |readStart|, throw a {{TypeError}}.
 1. If |readStart| is larger than |fileSize|:
     1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to |fileSize|.
     1. Return 0.
@@ -1117,6 +1119,8 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
 1. Let |writePosition| be |options|["{{FileSystemReadWriteOptions/at}}"] if
    |options|["{{FileSystemReadWriteOptions/at}}"] [=map/exists=]; otherwise
    [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=].
+1. If the underlying file system does not support writing to a file offset of
+   |writePosition|, throw a {{TypeError}}.
 1. Let |fileContents| be a copy of [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. Let |oldSize| be |fileContents|'s [=byte sequence/length=].
 1. Let |bufferSize| be |buffer|'s [=byte length=].
@@ -1169,6 +1173,8 @@ The <dfn method for=FileSystemSyncAccessHandle>truncate(|newSize|)</dfn> method 
 1. If [=this=].[=[[state]]=] is "`closed`", throw an {{InvalidStateError}}.
 1. Let |fileContents| be a copy of [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. 1. Let |oldSize| be the [=byte sequence/length=] of [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
+1. If the underlying file system does not support setting a file's size to
+   |newSize|, throw a {{TypeError}}.
 1. If |newSize| is larger than |oldSize|:
    1. If |newSize| &minus; |oldSize| exceeds the available [=storage quota=], throw a {{QuotaExceededError}}.
    1. Set [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s to a [=byte sequence=] formed by concatenating

--- a/index.bs
+++ b/index.bs
@@ -1082,7 +1082,7 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
    |options|["{{FileSystemReadWriteOptions/at}}"] [=map/exists=]; otherwise
    [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=].
 1. If the underlying file system does not support reading from a file offset of
-   |readStart|, throw a {{TypeError}}.
+   |readStart|, [=throw=] a {{TypeError}}.
 1. If |readStart| is larger than |fileSize|:
     1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to |fileSize|.
     1. Return 0.


### PR DESCRIPTION
Fixes #31


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/84.html" title="Last updated on Jan 11, 2023, 9:41 PM UTC (5978da3)">Preview</a> | <a href="https://whatpr.org/fs/84/048a672...5978da3.html" title="Last updated on Jan 11, 2023, 9:41 PM UTC (5978da3)">Diff</a>