### PR TITLE
Editorial: Change exceptions to be more precise - part 2

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -212,7 +212,7 @@ Their [=deserialization steps=], given |serialized| and |value| are:
 
 1. If |serialized|.\[[Origin]] is not [=same origin=] with
    |value|'s [=relevant settings object=]'s [=environment settings object/origin=],
-   then throw a {{DataCloneError}}.
+   then throw a "{{DataCloneError}}" {{DOMException}}.
 1. Set |value|'s [=FileSystemHandle/entry=] to |serialized|.\[[Entry]]
 
 </div>
@@ -462,7 +462,7 @@ and its async iterator |iterator| are:
    [=file system entry/query access=] given "`read`".
 
 1. If |access| is not "{{PermissionState/granted}}",
-   throw a {{NotAllowedError}}.
+   throw a "{{NotAllowedError}}" {{DOMException}}.
 
 1. Set |iterator|'s <dfn for="FileSystemDirectoryHandle-iterator">past results</dfn> to an empty [=/set=].
 
@@ -674,7 +674,7 @@ The <dfn method for=FileSystemDirectoryHandle>removeEntry(|name|, |options|)</df
 
          Issue(11): Better specify what possible exceptions this could throw.
       1. [=/Resolve=] |result| with `undefined`.
-  1. [=/Reject=] |result| with a {{NotFoundError}}.
+  1. [=/Reject=] |result| with a "{{NotFoundError}}" {{DOMException}}.
 1. Return |result|.
 
 </div>
@@ -1073,7 +1073,8 @@ Issue(35): Specify how Access Handles should react when reading from a file that
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWriteOptions}}: |options|)</dfn> method steps are:
 
-1. If [=this=].[=[[state]]=] is "`closed`", throw an {{InvalidStateError}}.
+1. If [=this=].[=[[state]]=] is "`closed`", throw an "{{InvalidStateError}}"
+   {{DOMException}}.
 1. Let |bufferSize| be |buffer|'s [=byte length=].
 1. Let |fileContents| be [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. Let |fileSize| be |fileContents|'s [=byte sequence/length=].
@@ -1114,7 +1115,8 @@ The <dfn method for=FileSystemSyncAccessHandle>read(|buffer|, {{FileSystemReadWr
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadWriteOptions}}: |options|)</dfn> method steps are:
 
-1. If [=this=].[=[[state]]=] is "`closed`", throw an {{InvalidStateError}}.
+1. If [=this=].[=[[state]]=] is "`closed`", throw an "{{InvalidStateError}}"
+   {{DOMException}}.
 1. Let |writePosition| be |options|["{{FileSystemReadWriteOptions/at}}"] if
    |options|["{{FileSystemReadWriteOptions/at}}"] [=map/exists=]; otherwise
    [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=].
@@ -1137,7 +1139,8 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
    1. Set |tail| to a [=byte sequence=] containing the last
       |oldSize| &minus; (|writePosition| + |bufferSize|) bytes of |fileContents|.
 1. Let |newSize| be |head|'s [=byte sequence/length=] + |bufferSize| + |tail|'s [=byte sequence/length=].
-1. If |newSize| &minus; |oldSize| exceeds the available [=storage quota=], throw a {{QuotaExceededError}}.
+1. If |newSize| &minus; |oldSize| exceeds the available [=storage quota=],
+   throw a "{{QuotaExceededError}}" {{DOMException}}.
 1. Set [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=] to the concatenation of |head|, the contents of |buffer| and |tail|.
 
   Note: The mechanism used to access buffer's contents is left purposely vague.
@@ -1151,7 +1154,7 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
         1. Let |bytesWritten| be the number of bytes that were written from |buffer|.
         1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to |writePosition| + |bytesWritten|.
         1. Return |bytesWritten|.
-    1. Otherwise throw an {{InvalidStateError}}.
+    1. Otherwise throw an "{{InvalidStateError}}" {{DOMException}}.
 1. Set [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] to |writePosition| + |bufferSize|.
 1. Return |bufferSize|.
 
@@ -1169,23 +1172,24 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>truncate(|newSize|)</dfn> method steps are:
 
-1. If [=this=].[=[[state]]=] is "`closed`", throw an {{InvalidStateError}}.
+1. If [=this=].[=[[state]]=] is "`closed`", throw an "{{InvalidStateError}}"
+   {{DOMException}}.
 1. Let |fileContents| be a copy of [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. 1. Let |oldSize| be the [=byte sequence/length=] of [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=].
 1. If the underlying file system does not support setting a file's size to
    |newSize|, throw a {{TypeError}}.
 1. If |newSize| is larger than |oldSize|:
-   1. If |newSize| &minus; |oldSize| exceeds the available [=storage quota=], throw a {{QuotaExceededError}}.
+   1. If |newSize| &minus; |oldSize| exceeds the available [=storage quota=], throw a "{{QuotaExceededError}}" {{DOMException}}.
    1. Set [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s to a [=byte sequence=] formed by concatenating
       |fileContents| with a [=byte sequence=]
       containing |newSize| &minus; |oldSize| 0x00 bytes.
    1. If the operations modifying the [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=] in the previous steps
-      failed, throw an {{InvalidStateError}}.
+      failed, throw an "{{InvalidStateError}}" {{DOMException}}.
 1. Otherwise, if |newSize| is smaller than |oldSize|:
    1. Set [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s to a [=byte sequence=] containing the first |newSize| bytes
       in |fileContents|.
    1. If the operations modifying the [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=] in the previous steps
-      failed, throw an {{InvalidStateError}}.
+      failed, throw an "{{InvalidStateError}}" {{DOMException}}.
 1. If [=this=]'s [=FileSystemSyncAccessHandle/file position cursor=] is greater than |newSize|, then set [=FileSystemSyncAccessHandle/file position cursor=] to |newSize|.
 
 </div>
@@ -1200,7 +1204,8 @@ The <dfn method for=FileSystemSyncAccessHandle>truncate(|newSize|)</dfn> method 
 <div algorithm>
 The <dfn method for=FileSystemSyncAccessHandle>getSize()</dfn> method steps are:
 
-1. If [=this=].[=[[state]]=] is "`closed`", throw an {{InvalidStateError}}.
+1. If [=this=].[=[[state]]=] is "`closed`", throw an "{{InvalidStateError}}"
+   {{DOMException}}.
 1. Return [=this=].[=FileSystemSyncAccessHandle/[[file]]=]'s [=file entry/binary data=]'s [=byte sequence/length=].
 
 </div>
@@ -1281,7 +1286,7 @@ The <dfn method for=StorageManager>getDirectory()</dfn> method steps are:
 
 1. Let |map| be the result of running [=obtain a local storage bottle map=]
    with |environment| and `"fileSystem"`. If this returns failure,
-   return [=a promise rejected with=] a {{SecurityError}}.
+   return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 
 1. If |map|["root"] does not [=map/exist=]:
   1. Let |dir| be a new [=directory entry=] whose [=query access=] and [=request access=] algorithms


### PR DESCRIPTION
Fixes #63

These should have been fixed in #70 but clearly I missed some ¯\\_(ツ)_/¯


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/88.html" title="Last updated on Jan 12, 2023, 12:56 AM UTC (a91ecef)">Preview</a> | <a href="https://whatpr.org/fs/88/149f02e...a91ecef.html" title="Last updated on Jan 12, 2023, 12:56 AM UTC (a91ecef)">Diff</a>