### PR TITLE
Editorial: Point "serializable objects" reference to HTML spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14,6 +14,8 @@ spec:webidl; type:dfn; text:resolve
 </pre>
 
 <pre class=anchors>
+urlPrefix: https://html.spec.whatwg.org/; spec: html
+  type: dfn; text: serializable objects; url: serializable-objects
 urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
   type: dfn; text: realm; url: realm
 urlPrefix: https://storage.spec.whatwg.org/; spec: storage


### PR DESCRIPTION
Builds are currently failing with the following error:
```
LINK ERROR: No 'dfn' refs found for 'serializable objects' that are marked for export.
[=serializable objects=]
```

Looks like this ref may now be overloaded? Regardless, this fixes the build error


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/94.html" title="Last updated on Jan 17, 2023, 10:24 PM UTC (956219a)">Preview</a> | <a href="https://whatpr.org/fs/94/2b0a522...956219a.html" title="Last updated on Jan 17, 2023, 10:24 PM UTC (956219a)">Diff</a>