### PR TITLE
Define a parallel queue for all file system operations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -67,7 +67,7 @@ algorithm, which takes "`read`" or "`readwrite`" <var ignore>mode</var> and
 returns a [=/file system access result=].
 Unless specified otherwise it returns a [=/file system access result=] with a
 [=file system access result/permission state=] of "{{PermissionState/denied}}"
-and with a [=file system access result/error name=] of « the empty string ».
+and with a [=file system access result/error name=] of the empty string.
 
 Each [=/file system entry=] has an associated
 <dfn for="file system entry" id=entry-request-access>request access</dfn>
@@ -75,7 +75,7 @@ algorithm, which takes "`read`" or "`readwrite`" <var ignore>mode</var> and
 returns a [=/file system access result=].
 Unless specified otherwise it returns a [=/file system access result=] with a
 [=file system access result/permission state=] of "{{PermissionState/denied}}"
-and with a [=file system access result/error name=] of « the empty string ».
+and with a [=file system access result/error name=] of the empty string.
 
 A <dfn export>file system access result</dfn> is a [=struct=] encapsulating the
 result of [=file system entry/query access|querying=] or
@@ -85,10 +85,13 @@ It has the following [=struct/items=]:
 : <dfn for="file system access result">permission state</dfn>
 :: A {{PermissionState}}
 : <dfn for="file system access result">error name</dfn>
-:: A [=string=] which must be either « the empty string » or an
+:: A [=string=] which must be either the empty string or an
    [=exception/error name=] listed in the [=error names table=].
-   If [=file system access result/permission state=] is
-   "{{PermissionState/granted}}" this must be « the empty string »
+   Iff [=file system access result/permission state=] is
+   "{{PermissionState/granted}}" this will be the empty string.
+   It is expected that in most cases when
+   [=file system access result/permission state=] is not
+   "{{PermissionState/granted}}", this will be "{{NotAllowedError}}".
 
 <p class=warning> Dependent specifications may consider this API a
 [=powerful feature=]. However, unlike other [=powerful features=] whose
@@ -98,7 +101,7 @@ algorithms must run [=in parallel=] on the [=file system queue=] and are
 therefore not allowed to throw. Instead, the caller is expected to
 [=queue a storage task=] to [=/reject=], as appropriate,
 should these algorithms return an [=file system access result/error name=]
-other than « the empty string ».
+other than the empty string.
 
 Note: Implementations that only implement this specification and not dependent
 specifications do not need to bother implementing [=/file system entry=]'s
@@ -477,12 +480,9 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method steps are:
 
   1. [=Queue a storage task=] with |global| to run these steps:
     1. If |accessResult|'s [=file system access result/permission state=]
-       is not "{{PermissionState/granted}}":
-      1. Set |accessErrorName| to |accessResult|'s
-         [=file system access result/error name=] if it is not
-         « the empty string »; otherwise "{{NotAllowedError}}".
-      1. [=/Reject=] |result| with an |accessErrorName| {{DOMException}} and
-         abort these steps.
+       is not "{{PermissionState/granted}}", [=/reject=] |result| with a
+       {{DOMException}} of |accessResult|'s
+       [=file system access result/error name=] and abort these steps.
 
     1. If |entry| is null, [=/reject=] |result| with a
        "{{NotFoundError}}" {{DOMException}} and abort these steps.
@@ -550,12 +550,10 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method 
   1. Let |accessResult| be the result of running |entry|'s
      [=file system entry/request access=] given "`readwrite`".
   1. If |accessResult|'s [=file system access result/permission state=]
-     is not "{{PermissionState/granted}}":
-    1. Set |accessErrorName| to |accessResult|'s
-       [=file system access result/error name=] if it is not
-       « the empty string »; otherwise "{{NotAllowedError}}".
-    1. [=Queue a storage task=] with |global| to [=/reject=] |result| with an
-       |accessErrorName| {{DOMException}} and abort these steps.
+     is not "{{PermissionState/granted}}", [=queue a storage task=] with
+     |global| to [=/reject=] |result| with a {{DOMException}} of
+     |accessResult|'s [=file system access result/error name=] and
+     abort these steps.
 
   1. If |entry| is `null`, [=queue a storage task=] with |global| to [=/reject=]
      |result| with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
@@ -612,12 +610,10 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method s
   1. Let |accessResult| be the result of running |entry|'s
      [=file system entry/request access=] given "`readwrite`".
   1. If |accessResult|'s [=file system access result/permission state=]
-     is not "{{PermissionState/granted}}":
-    1. Set |accessErrorName| to |accessResult|'s
-       [=file system access result/error name=] if it is not
-       « the empty string »; otherwise "{{NotAllowedError}}".
-    1. [=Queue a storage task=] with |global| to [=/reject=] |result| with an
-       |accessErrorName| {{DOMException}} and abort these steps.
+     is not "{{PermissionState/granted}}", [=queue a storage task=] with
+     |global| to [=/reject=] |result| with a {{DOMException}} of
+     |accessResult|'s [=file system access result/error name=] and
+     abort these steps.
 
   1. If |entry| is `null`, [=queue a storage task=] with |global| to [=/reject=]
      |result| with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
@@ -727,20 +723,9 @@ Issue(15): In the future we might want to add arguments to the async iterable de
 support for example recursive iteration.
 
 <div algorithm="iterator initialization">
-The [=asynchronous iterator initialization steps=] for a {{FileSystemDirectoryHandle}} |handle|
+The [=asynchronous iterator initialization steps=] for a
+{{FileSystemDirectoryHandle}} <var ignore>handle</var>
 and its async iterator |iterator| are:
-
-1. [=Enqueue the following steps=] to the [=file system queue=]:
-  1. Let |entry| be the result of [=locating an entry=]
-     given |handle|'s [=FileSystemHandle/locator=].
-  1. Let |accessResult| be the result of running |entry|'s
-     [=file system entry/query access=] given "`read`".
-  1. If |accessResult|'s [=file system access result/permission state=]
-     is not "{{PermissionState/granted}}":
-    1. Set |accessErrorName| to |accessResult|'s
-       [=file system access result/error name=] if it is not
-       « the empty string »; otherwise "{{NotAllowedError}}".
-    1. [=Throw=] an |accessErrorName| {{DOMException}}.
 
 1. Set |iterator|'s <dfn for="FileSystemDirectoryHandle-iterator">past results</dfn> to an empty [=/set=].
 
@@ -760,12 +745,9 @@ and its async iterator |iterator|:
   1. [=Queue a storage task=] with |handle|'s [=relevant global object=] to
      run these steps:
     1. If |accessResult|'s [=file system access result/permission state=]
-       is not "{{PermissionState/granted}}":
-      1. Set |accessErrorName| to |accessResult|'s
-         [=file system access result/error name=] if it is not
-         « the empty string »; otherwise "{{NotAllowedError}}".
-      1. [=/Reject=] |promise| with an |accessErrorName| {{DOMException}}
-         and return |promise|.
+       is not "{{PermissionState/granted}}", [=/reject=] |promise| with a
+       {{DOMException}} of |accessResult|'s
+       [=file system access result/error name=] and abort these steps.:
 
     1. If |directory| is `null`, [=/reject=] |result| with a
        "{{NotFoundError}}" {{DOMException}} and abort these steps.
@@ -849,12 +831,9 @@ The <dfn method for=FileSystemDirectoryHandle>getFileHandle(|name|, |options|)</
 
   1. [=Queue a storage task=] with |global| to run these steps:
     1. If |accessResult|'s [=file system access result/permission state=]
-       is not "{{PermissionState/granted}}":
-      1. Set |accessErrorName| to |accessResult|'s
-         [=file system access result/error name=] if it is not
-         « the empty string »; otherwise "{{NotAllowedError}}".
-      1. [=/Reject=] |result| with an |accessErrorName| {{DOMException}} and
-         abort these steps.
+       is not "{{PermissionState/granted}}", [=/reject=] |result| with a
+       {{DOMException}} of |accessResult|'s
+       [=file system access result/error name=] and abort these steps.
 
     1. If |entry| is `null`, [=/reject=] |result| with a
        "{{NotFoundError}}" {{DOMException}} and abort these steps.
@@ -934,12 +913,9 @@ The <dfn method for=FileSystemDirectoryHandle>getDirectoryHandle(|name|, |option
 
   1. [=Queue a storage task=] with |global| to run these steps:
     1. If |accessResult|'s [=file system access result/permission state=]
-       is not "{{PermissionState/granted}}":
-      1. Set |accessErrorName| to |accessResult|'s
-         [=file system access result/error name=] if it is not
-         « the empty string »; otherwise "{{NotAllowedError}}".
-      1. [=/Reject=] |result| with an |accessErrorName| {{DOMException}} and
-         abort these steps.
+       is not "{{PermissionState/granted}}", [=/reject=] |result| with a
+       {{DOMException}} of |accessResult|'s
+       [=file system access result/error name=] and abort these steps.
 
     1. If |entry| is `null`, [=/reject=] |result| with a
        "{{NotFoundError}}" {{DOMException}} and abort these steps.
@@ -1010,12 +986,9 @@ The <dfn method for=FileSystemDirectoryHandle>removeEntry(|name|, |options|)</df
 
   1. [=Queue a storage task=] with |global| to run these steps:
     1. If |accessResult|'s [=file system access result/permission state=]
-       is not "{{PermissionState/granted}}":
-      1. Set |accessErrorName| to |accessResult|'s
-         [=file system access result/error name=] if it is not
-         « the empty string »; otherwise "{{NotAllowedError}}".
-      1. [=/Reject=] |result| with an |accessErrorName| {{DOMException}} and
-         abort these steps.
+       is not "{{PermissionState/granted}}", [=/reject=] |result| with a
+       {{DOMException}} of |accessResult|'s
+       [=file system access result/error name=] and abort these steps.
 
     1. If |entry| is `null`, [=/reject=] |result| with a
        "{{NotFoundError}}" {{DOMException}} and abort these steps.
@@ -1172,13 +1145,9 @@ given a [=file entry=] |file| in a [=/Realm=] |realm|:
       1. [=Queue a storage task=] with |file|'s [=relevant global object=]
          to run these steps:
         1. If |accessResult|'s [=file system access result/permission state=]
-           is not "{{PermissionState/granted}}":
-          1. Set |accessErrorName| to |accessResult|'s
-             [=file system access result/error name=] if it is not
-             « the empty string »; otherwise "{{NotAllowedError}}".
-          1. [=/Reject=] |closeResult| with an
-             |accessErrorName| {{DOMException}} and abort these steps.
-
+           is not "{{PermissionState/granted}}", [=/reject=] |closeResult|
+           with a {{DOMException}} of |accessResult|'s
+           [=file system access result/error name=] and abort these steps.
         1. Run [=implementation-defined=] malware scans and safe browsing checks.
            If these checks fail, [=/reject=] |closeResult| with an
            "{{AbortError}}" {{DOMException}} and abort these steps.
@@ -1229,12 +1198,9 @@ runs these steps:
   1. [=Queue a storage task=] with |stream|'s [=relevant global object=] to
      run these steps:
     1. If |accessResult|'s [=file system access result/permission state=]
-       is not "{{PermissionState/granted}}":
-      1. Set |accessErrorName| to |accessResult|'s
-         [=file system access result/error name=] if it is not
-         « the empty string »; otherwise "{{NotAllowedError}}".
-      1. [=/Reject=] |p| with an |accessErrorName| {{DOMException}} and
-         abort these steps.
+       is not "{{PermissionState/granted}}", [=/reject=] |p| with a
+       {{DOMException}} of |accessResult|'s
+       [=file system access result/error name=] and abort these steps.
 
     1. Let |command| be |input|.{{WriteParams/type}} if |input| is a {{WriteParams}},
        and {{WriteCommandType/"write"}} otherwise.
@@ -1705,7 +1671,7 @@ The <dfn method for=StorageManager>getDirectory()</dfn> method steps are:
      a [=/file system access result=]
      with a [=file system access result/permission state=]
      of "{{PermissionState/granted}}" and
-     with a [=file system access result/error name=] of « the empty string ».
+     with an [=file system access result/error name=] of the empty string.
   1. Set |dir|'s [=file system entry/name=] to the empty string.
   1. Set |dir|'s [=directory entry/children=] to an empty [=/set=].
   1. Set |map|["root"] to |dir|.

--- a/index.bs
+++ b/index.bs
@@ -94,24 +94,29 @@ A <dfn export id=file>file entry</dfn> additionally consists of
 a <dfn for="file entry">lock</dfn> (a string that may exclusively be "`open`", "`taken-exclusive`" or "`taken-shared`")
 and a <dfn for="file entry">shared lock count</dfn> (a number representing the number shared locks that are taken at a given point in time).
 
+The <dfn id="file-system-lock-queue">file system lock queue</dfn> is a
+[=parallel queue=] to be used for all <a for=/>tasks</a> involving a
+[=file entry/lock=].
+
 <div algorithm>
 To <dfn for="file entry/lock">take</dfn> a [=file entry/lock=] with a |value| of "`exclusive`" or "`shared`" on a given [=file entry=] |file|:
 
 1. Let |lock| be the |file|'s [=file entry/lock=].
-1. Let |count| be the |file|'s [=file entry/shared lock count=].
-1. If |value| is "`exclusive`":
-   1. If |lock| is "`open`":
-     1. Set lock to "`taken-exclusive`".
-     1. Return true.
-1. If |value| is "`shared`":
-   1. If |lock| is "`open`":
-     1. Set |lock| to "`taken-shared`".
-     1. Set |count| to 1.
-     1. Return true.
-   1. Otherwise, if |lock| is "`taken-shared`":
-     1. Increase |count| by one.
-     1. Return true.
-1. Return false.
+1. [=Enqueue the following steps=] to the [=file system lock queue=]:
+  1. Let |count| be the |file|'s [=file entry/shared lock count=].
+  1. If |value| is "`exclusive`":
+     1. If |lock| is "`open`":
+       1. Set lock to "`taken-exclusive`".
+       1. Return true.
+  1. If |value| is "`shared`":
+     1. If |lock| is "`open`":
+       1. Set |lock| to "`taken-shared`".
+       1. Set |count| to 1.
+       1. Return true.
+     1. Otherwise, if |lock| is "`taken-shared`":
+       1. Increase |count| by one.
+       1. Return true.
+  1. Return false.
 
 </div>
 
@@ -120,11 +125,12 @@ To <dfn for="file entry/lock">release</dfn> a [=file entry/lock=] on a given [=f
 run these steps:
 
 1. Let |lock| be the |file|'s associated [=file entry/lock=].
-1. Let |count| be the |file|'s [=file entry/shared lock count=].
-1. If |lock| is "`taken-shared`":
-  1. Decrease |count| by one.
-  1. If |count| is 0, set |lock| to "`open`".
-1. Otherwise, set |lock| to "`open`".
+1. [=Enqueue the following steps=] to the [=file system lock queue=]:
+  1. Let |count| be the |file|'s [=file entry/shared lock count=].
+  1. If |lock| is "`taken-shared`":
+    1. Decrease |count| by one.
+    1. If |count| is 0, set |lock| to "`open`".
+  1. Otherwise, set |lock| to "`open`".
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -109,20 +109,23 @@ algorithm |resultAlgorithm|:
   1. If |value| is "`exclusive`":
      1. If |lock| is "`open`":
        1. Set lock to "`taken-exclusive`".
-       1. [=Queue a global task=] on the [=storage task source=] to run
-          |resultAlgorithm| with a value of "`success`" and return.
+       1. [=Queue a storage task=] given |file|'s [=relevant global object=] and
+          |resultAlgorithm| with a value of "`success`".
+       1. Return.
   1. If |value| is "`shared`":
      1. If |lock| is "`open`":
        1. Set |lock| to "`taken-shared`".
        1. Set |count| to 1.
-       1. [=Queue a global task=] on the [=storage task source=] to run
-          |resultAlgorithm| with a value of "`success`" and return.
+       1. [=Queue a storage task=] given |file|'s [=relevant global object=] and
+          |resultAlgorithm| with a value of "`success`".
+       1. Return.
      1. Otherwise, if |lock| is "`taken-shared`":
-       1. Increase |count| by one.
-       1. [=Queue a global task=] on the [=storage task source=] to run
-          |resultAlgorithm| with a value of "`success`" and return.
-  1. [=Queue a global task=] on the [=storage task source=] to run
-     |resultAlgorithm| with a value of "`failure`" and return.
+       1. Increase |count| by 1.
+       1. [=Queue a storage task=] given |file|'s [=relevant global object=] and
+          |resultAlgorithm| with a value of "`success`".
+       1. Return.
+  1. [=Queue a storage task=] given |file|'s [=relevant global object=] and
+     |resultAlgorithm| with a value of "`failure`".
 
 </div>
 
@@ -134,11 +137,11 @@ To <dfn for="file entry/lock">release</dfn> a [=file entry/lock=] on a given
   1. Let |lock| be the |file|'s associated [=file entry/lock=].
   1. Let |count| be the |file|'s [=file entry/shared lock count=].
   1. If |lock| is "`taken-shared`":
-    1. Decrease |count| by one.
+    1. Decrease |count| by 1.
     1. If |count| is 0, set |lock| to "`open`".
   1. Otherwise, set |lock| to "`open`".
-  1. If |onLockReleasedAlgorithm| was given, [=queue a global task=] on the
-     [=storage task source=] to run |onLockReleasedAlgorithm|.
+  1. If |onLockReleasedAlgorithm| was given, [=queue a storage task=] given
+     |file|'s [=relevant global object=] and |onLockReleasedAlgorithm|.
 
 </div>
 
@@ -1519,10 +1522,11 @@ The <dfn method for=FileSystemSyncAccessHandle>close()</dfn> method steps are:
 
 1. If [=this=]'s [=[[state]]=] is "`closed`", return.
 1. Set [=this=]'s [=[[state]]=] to "`closed`".
-1. Let |onLockReleasedAlgorithm| be an algorithm that does nothing.
+1. Set |lockReleased| to false.
+1. Let |onLockReleasedAlgorithm| be this step: Set |lockReleased| to true.
 1. [=file entry/lock/release|Release the lock=] on
    [=this=]'s [=FileSystemSyncAccessHandle/[[file]]=] with |onLockReleasedAlgorithm|.
-1. Wait for |onLockReleasedAlgorithm| to run.
+1. [=Pause=] until |lockReleased| is set to true.
 
 Note: This method does not guarantee that all file modifications will be
 immediately reflected in the underlying storage device. Call the

--- a/index.bs
+++ b/index.bs
@@ -88,7 +88,7 @@ It has the following [=struct/items=]:
 :: A [=string=] which must be the empty string if
    [=file system access result/permission state=] is
    "{{PermissionState/granted}}"; otherwise an
-   [=exception/error name=] listed in the [=error names table=].
+   [=DOMException/name=] listed in the [=`DOMException` names table=].
    It is expected that in most cases when
    [=file system access result/permission state=] is not
    "{{PermissionState/granted}}", this should be "{{NotAllowedError}}".

--- a/index.bs
+++ b/index.bs
@@ -67,7 +67,7 @@ algorithm, which takes "`read`" or "`readwrite`" <var ignore>mode</var> and
 returns a [=/file system access result=].
 Unless specified otherwise it returns a [=/file system access result=] with a
 [=file system access result/permission state=] of "{{PermissionState/denied}}"
-and with a [=file system access result/error name=] of the empty string.
+and with an [=file system access result/error name=] of the empty string.
 
 Each [=/file system entry=] has an associated
 <dfn for="file system entry" id=entry-request-access>request access</dfn>
@@ -75,7 +75,7 @@ algorithm, which takes "`read`" or "`readwrite`" <var ignore>mode</var> and
 returns a [=/file system access result=].
 Unless specified otherwise it returns a [=/file system access result=] with a
 [=file system access result/permission state=] of "{{PermissionState/denied}}"
-and with a [=file system access result/error name=] of the empty string.
+and with an [=file system access result/error name=] of the empty string.
 
 A <dfn export>file system access result</dfn> is a [=struct=] encapsulating the
 result of [=file system entry/query access|querying=] or
@@ -85,13 +85,13 @@ It has the following [=struct/items=]:
 : <dfn for="file system access result">permission state</dfn>
 :: A {{PermissionState}}
 : <dfn for="file system access result">error name</dfn>
-:: A [=string=] which must be either the empty string or an
+:: A [=string=] which must be the empty string if
+   [=file system access result/permission state=] is
+   "{{PermissionState/granted}}"; otherwise an
    [=exception/error name=] listed in the [=error names table=].
-   Iff [=file system access result/permission state=] is
-   "{{PermissionState/granted}}" this will be the empty string.
    It is expected that in most cases when
    [=file system access result/permission state=] is not
-   "{{PermissionState/granted}}", this will be "{{NotAllowedError}}".
+   "{{PermissionState/granted}}", this should be "{{NotAllowedError}}".
 
 <p class=warning> Dependent specifications may consider this API a
 [=powerful feature=]. However, unlike other [=powerful features=] whose

--- a/index.bs
+++ b/index.bs
@@ -577,13 +577,6 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method s
 
   1. If |entry| does not represent a [=/file system entry=] in an [=origin private file system=],
      [=reject=] |result| with an "{{InvalidStateError}}" {{DOMException}} and abort.
-<<<<<<< HEAD
-  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with "`exclusive`" on |entry|.
-  1. If |lockResult| is false, [=reject=] |result| with a "{{NoModificationAllowedError}}" {{DOMException}} and abort.
-  1. Let |handle| be the result of <a>creating a new `FileSystemSyncAccessHandle`</a>
-     for |entry| in [=this=]'s [=relevant realm=].
-  1. [=/Resolve=] |result| with |handle|.
-=======
   1. Let |lockResultAlgorithm| be an algorithm which takes a |lockResult| and
      runs these steps:
      1. If |lockResult| is "`failure`", [=reject=] |result| with a
@@ -591,9 +584,8 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method s
      1. Let |handle| be the result of <a>creating a new `FileSystemSyncAccessHandle`</a>
         for |entry| in [=this=]'s [=relevant realm=].
      1. [=/Resolve=] |result| with |handle|.
-  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
-     with "`exclusive`" on |entry| and with |lockResultAlgorithm|.
->>>>>>> f840b90 (pass only one algorithm)
+  1. [=file entry/lock/take|Take a lock=] with "`exclusive`" on |entry| and with
+     |lockResultAlgorithm|.
 1. Return |result|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -94,42 +94,51 @@ A <dfn export id=file>file entry</dfn> additionally consists of
 a <dfn for="file entry">lock</dfn> (a string that may exclusively be "`open`", "`taken-exclusive`" or "`taken-shared`")
 and a <dfn for="file entry">shared lock count</dfn> (a number representing the number shared locks that are taken at a given point in time).
 
-The <dfn id="file-system-lock-queue">file system lock queue</dfn> is a
-[=parallel queue=] to be used for all [=tasks=] involving a [=file entry/lock=].
+A user agent has an associated <dfn>file system lock queue</dfn> which is the
+result of [=starting a new parallel queue=]. This queue is to be used for all
+[=tasks=] involving a [=file entry/lock=].
 
 <div algorithm>
-To <dfn for="file entry/lock">take</dfn> a [=file entry/lock=] with a |value| of "`exclusive`" or "`shared`" on a given [=file entry=] |file|:
+To <dfn for="file entry/lock">take</dfn> a [=file entry/lock=] with a |value| of
+"`exclusive`" or "`shared`" on a given [=file entry=] |file|, with promise |p|,
+algorithm |onLockTakenAlgorithm|, and [=task source=] |replyTaskSource|:
 
-1. Let |lock| be the |file|'s [=file entry/lock=].
 1. [=Enqueue the following steps=] to the [=file system lock queue=]:
+  1. Let |lock| be the |file|'s [=file entry/lock=].
   1. Let |count| be the |file|'s [=file entry/shared lock count=].
   1. If |value| is "`exclusive`":
      1. If |lock| is "`open`":
        1. Set lock to "`taken-exclusive`".
-       1. Return true.
+       1. [=Queue a task=] to |replyTaskSource| to run |onLockTakenAlgorithm|
+          and return.
   1. If |value| is "`shared`":
      1. If |lock| is "`open`":
        1. Set |lock| to "`taken-shared`".
        1. Set |count| to 1.
-       1. Return true.
+       1. [=Queue a task=] to |replyTaskSource| to run |onLockTakenAlgorithm|
+          and return.
      1. Otherwise, if |lock| is "`taken-shared`":
        1. Increase |count| by one.
-       1. Return true.
-  1. Return false.
+       1. [=Queue a task=] to |replyTaskSource| to run |onLockTakenAlgorithm|
+          and return.
+  1. [=Reject=] |p| with a "{{NoModificationAllowedError}}" {{DOMException}}.
 
 </div>
 
 <div algorithm>
-To <dfn for="file entry/lock">release</dfn> a [=file entry/lock=] on a given [=file entry=] |file|,
-run these steps:
+To <dfn for="file entry/lock">release</dfn> a [=file entry/lock=] on a given
+[=file entry=] |file| with algorithm |onLockReleasedAlgorithm| and
+[=task source=] |replyTaskSource|:
 
-1. Let |lock| be the |file|'s associated [=file entry/lock=].
 1. [=Enqueue the following steps=] to the [=file system lock queue=]:
+  1. Let |lock| be the |file|'s associated [=file entry/lock=].
   1. Let |count| be the |file|'s [=file entry/shared lock count=].
   1. If |lock| is "`taken-shared`":
     1. Decrease |count| by one.
     1. If |count| is 0, set |lock| to "`open`".
   1. Otherwise, set |lock| to "`open`".
+  1. [=Queue a task=] to |replyTaskSource| to run |onLockReleasedAlgorithm|
+      and return.
 
 </div>
 
@@ -506,18 +515,17 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method 
      If that throws an exception, [=reject=] |result| with that exception and abort.
   1. If |access| is not "{{PermissionState/granted}}",
      [=reject=] |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
-
   1. If |entry| is `null`, [=/reject=] |result| with a
      "{{NotFoundError}}" {{DOMException}} and abort.
   1. [=Assert=]: |entry| is a [=file entry=].
-
-  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with "`shared`" on |entry|.
-  1. If |lockResult| is false, [=reject=] |result| with a "{{NoModificationAllowedError}}" {{DOMException}} and abort.
-  1. Let |stream| be the result of <a>creating a new `FileSystemWritableFileStream`</a>
-     for |entry| in [=this=]'s [=relevant realm=].
-  1. If |options|.{{FileSystemCreateWritableOptions/keepExistingData}} is true:
-    1. Set |stream|.[=[[buffer]]=] to a copy of |entry|'s [=file entry/binary data=].
-  1. [=/Resolve=] |result| with |stream|.
+  1. Let |onLockTakenAlgorithm| be these steps:
+    1. Let |stream| be the result of <a>creating a new `FileSystemWritableFileStream`</a>
+       for |entry| in [=this=]'s [=relevant realm=].
+    1. If |options|.{{FileSystemCreateWritableOptions/keepExistingData}} is true:
+      1. Set |stream|.[=[[buffer]]=] to a copy of |entry|'s [=file entry/binary data=].
+    1. [=/Resolve=] |result| with |stream|.
+  1. [=file entry/lock/take|Take a lock=] with "`shared`" on |entry| with
+     |result|, |onLockTakenAlgorithm|, and [=storage task source=].
 1. Return |result|.
 
 </div>
@@ -1055,8 +1063,9 @@ given a [=file entry=] |file| in a [=/Realm=] |realm|:
          Note: It is expected that this atomically updates the contents of the file on disk
          being written to.
 
-      1. [=file entry/lock/release|Release the lock=] on |stream|.[=FileSystemWritableFileStream/[[file]]=].
-      1. [=/Resolve=] |closeResult| with `undefined`.
+      1. Let |onLockReleasedAlgorithm| be this step: [=/Resolve=] |closeResult| with `undefined`.
+      1. [=file entry/lock/release|Release the lock=] on |stream|'s [=FileSystemWritableFileStream/[[file]]=]
+         with |onLockReleasedAlgorithm|, and the currently running [=task=]'s' [=task source|source=].
    1. Return |closeResult|.
 1. Let |abortAlgorithm| be this step: [=file entry/lock/release|release the lock=] on
    |stream|.[=FileSystemWritableFileStream/[[file]]=].

--- a/index.bs
+++ b/index.bs
@@ -94,54 +94,46 @@ A <dfn export id=file>file entry</dfn> additionally consists of
 a <dfn for="file entry">lock</dfn> (a string that may exclusively be "`open`", "`taken-exclusive`" or "`taken-shared`")
 and a <dfn for="file entry">shared lock count</dfn> (a number representing the number shared locks that are taken at a given point in time).
 
-A user agent has an associated <dfn>file system lock queue</dfn> which is the
+A user agent has an associated <dfn>file system queue</dfn> which is the
 result of [=starting a new parallel queue=]. This queue is to be used for all
-[=tasks=] involving a [=file entry/lock=].
+file sytem operations.
 
 <div algorithm>
 To <dfn for="file entry/lock">take</dfn> a [=file entry/lock=] with a |value| of
-"`exclusive`" or "`shared`" on a given [=file entry=] |file| and with
-algorithm |resultAlgorithm|:
+"`exclusive`" or "`shared`" on a given [=file entry=] |file|:
 
-1. [=Enqueue the following steps=] to the [=file system lock queue=]:
-  1. Let |lock| be the |file|'s [=file entry/lock=].
-  1. Let |count| be the |file|'s [=file entry/shared lock count=].
-  1. If |value| is "`exclusive`":
-     1. If |lock| is "`open`":
-       1. Set lock to "`taken-exclusive`".
-       1. [=Queue a storage task=] given |file|'s [=relevant global object=] and
-          |resultAlgorithm| with a value of "`success`".
-       1. Return.
-  1. If |value| is "`shared`":
-     1. If |lock| is "`open`":
-       1. Set |lock| to "`taken-shared`".
-       1. Set |count| to 1.
-       1. [=Queue a storage task=] given |file|'s [=relevant global object=] and
-          |resultAlgorithm| with a value of "`success`".
-       1. Return.
-     1. Otherwise, if |lock| is "`taken-shared`":
-       1. Increase |count| by 1.
-       1. [=Queue a storage task=] given |file|'s [=relevant global object=] and
-          |resultAlgorithm| with a value of "`success`".
-       1. Return.
-  1. [=Queue a storage task=] given |file|'s [=relevant global object=] and
-     |resultAlgorithm| with a value of "`failure`".
+1. Let |lock| be the |file|'s [=file entry/lock=].
+1. Let |count| be the |file|'s [=file entry/shared lock count=].
+1. If |value| is "`exclusive`":
+   1. If |lock| is "`open`":
+     1. Set lock to "`taken-exclusive`".
+     1. Return a value of "`success`".
+1. If |value| is "`shared`":
+   1. If |lock| is "`open`":
+     1. Set |lock| to "`taken-shared`".
+     1. Set |count| to 1.
+     1. Return a value of "`success`".
+   1. Otherwise, if |lock| is "`taken-shared`":
+     1. Increase |count| by 1.
+     1. Return a value of "`success`".
+1. Return a value of "`failure`".
+
+Note: These steps must be run on the [=file system queue=].
 
 </div>
 
 <div algorithm>
 To <dfn for="file entry/lock">release</dfn> a [=file entry/lock=] on a given
-[=file entry=] |file| and with an optional algorithm |onLockReleasedAlgorithm|:
+[=file entry=] |file|:
 
-1. [=Enqueue the following steps=] to the [=file system lock queue=]:
-  1. Let |lock| be the |file|'s associated [=file entry/lock=].
-  1. Let |count| be the |file|'s [=file entry/shared lock count=].
-  1. If |lock| is "`taken-shared`":
-    1. Decrease |count| by 1.
-    1. If |count| is 0, set |lock| to "`open`".
-  1. Otherwise, set |lock| to "`open`".
-  1. If |onLockReleasedAlgorithm| was given, [=queue a storage task=] given
-     |file|'s [=relevant global object=] and |onLockReleasedAlgorithm|.
+1. Let |lock| be the |file|'s associated [=file entry/lock=].
+1. Let |count| be the |file|'s [=file entry/shared lock count=].
+1. If |lock| is "`taken-shared`":
+  1. Decrease |count| by 1.
+  1. If |count| is 0, set |lock| to "`open`".
+1. Otherwise, set |lock| to "`open`".
+
+Note: These steps must be run on the [=file system queue=].
 
 </div>
 
@@ -511,27 +503,32 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method 
 
 1. Let |result| be [=a new promise=].
 1. Let |locator| be [=this=]'s [=FileSystemHandle/locator=].
-1. Run these steps [=in parallel=]:
+1. Let |realm| be [=this=]'s [=relevant Realm=].
+1. [=Enqueue the following steps=] to the [=file system queue=]:
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
   1. Let |access| be the result of running |entry|'s
      [=file system entry/request access=] given "`readwrite`".
-     If that throws an exception, [=reject=] |result| with that exception and abort.
+     If that throws an exception, [=reject=] |result| with that exception and
+     abort these steps.
   1. If |access| is not "{{PermissionState/granted}}",
-     [=reject=] |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
+     [=reject=] |result| with a "{{NotAllowedError}}" {{DOMException}} and
+     abort these steps.
+
   1. If |entry| is `null`, [=/reject=] |result| with a
      "{{NotFoundError}}" {{DOMException}} and abort.
   1. [=Assert=]: |entry| is a [=file entry=].
-  1. Let |lockResultAlgorithm| be an algorithm which takes a |lockResult| and
-     runs these steps:
-    1. If |lockResult| is "`failure`", [=reject=] |result| with a
-       "{{NoModificationAllowedError}}" {{DOMException}} and abort.
-    1. Let |stream| be the result of <a>creating a new `FileSystemWritableFileStream`</a>
-       for |entry| in [=this=]'s [=relevant realm=].
-    1. If |options|.{{FileSystemCreateWritableOptions/keepExistingData}} is true:
-      1. Set |stream|.[=[[buffer]]=] to a copy of |entry|'s [=file entry/binary data=].
-    1. [=/Resolve=] |result| with |stream|.
-  1. [=file entry/lock/take|Take a lock=] with "`shared`" on |entry| and with
-     |lockResultAlgorithm|.
+
+  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
+     with "`shared`" on |entry|.
+  1. If |lockResult| is "`failure`", [=reject=] |result| with a
+     "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
+
+  1. Let |stream| be the result of <a>creating a new `FileSystemWritableFileStream`</a>
+     for |entry| in |realm|.
+  1. If |options|'s {{FileSystemCreateWritableOptions/keepExistingData}} is true:
+     1. Set |stream|'s [=[[buffer]]=] to a copy of |entry|'s [=file entry/binary data=].
+  1. [=/Resolve=] |result| with |stream|.
+
 1. Return |result|.
 
 </div>
@@ -563,29 +560,33 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method s
 
 1. Let |result| be [=a new promise=].
 1. Let |locator| be [=this=]'s [=FileSystemHandle/locator=].
-1. Run these steps [=in parallel=]:
+1. Let |realm| be [=this=]'s [=relevant Realm=].
+1. [=Enqueue the following steps=] to the [=file system queue=]:
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
   1. Let |access| be the result of running |entry|'s
      [=file system entry/request access=] given "`readwrite`".
-     If that throws an exception, [=reject=] |result| with that exception and abort.
-  1. If |access| is not "{{PermissionState/granted}}",
-     [=reject=] |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
+     If that throws an exception, [=reject=] |result| with that exception and
+     abort these steps.
+  1. If |access| is not "{{PermissionState/granted}}", [=reject=] |result| with
+     a "{{NotAllowedError}}" {{DOMException}} and abort these steps.
 
   1. If |entry| is `null`, [=/reject=] |result| with a
      "{{NotFoundError}}" {{DOMException}} and abort.
   1. [=Assert=]: |entry| is a [=file entry=].
 
   1. If |entry| does not represent a [=/file system entry=] in an [=origin private file system=],
-     [=reject=] |result| with an "{{InvalidStateError}}" {{DOMException}} and abort.
-  1. Let |lockResultAlgorithm| be an algorithm which takes a |lockResult| and
-     runs these steps:
-     1. If |lockResult| is "`failure`", [=reject=] |result| with a
-       "{{NoModificationAllowedError}}" {{DOMException}} and abort.
-     1. Let |handle| be the result of <a>creating a new `FileSystemSyncAccessHandle`</a>
-        for |entry| in [=this=]'s [=relevant realm=].
-     1. [=/Resolve=] |result| with |handle|.
-  1. [=file entry/lock/take|Take a lock=] with "`exclusive`" on |entry| and with
-     |lockResultAlgorithm|.
+     [=reject=] |result| with an "{{InvalidStateError}}" {{DOMException}} and
+     abort these steps.
+
+  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
+     with "`exclusive`" on |entry|.
+  1. If |lockResult| is "`failure`", [=reject=] |result| with a
+     "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
+
+  1. Let |handle| be the result of <a>creating a new `FileSystemSyncAccessHandle`</a>
+     for |entry| in |realm|.
+  1. [=/Resolve=] |result| with |handle|.
+
 1. Return |result|.
 
 </div>
@@ -1055,30 +1056,38 @@ To
 given a [=file entry=] |file| in a [=/Realm=] |realm|:
 
 1. Let |stream| be a [=new=] {{FileSystemWritableFileStream}} in |realm|.
-1. Set |stream|.[=FileSystemWritableFileStream/[[file]]=] to |file|.
+1. Set |stream|'s [=FileSystemWritableFileStream/[[file]]=] to |file|.
 1. Let |writeAlgorithm| be an algorithm which takes a |chunk| argument
    and returns the result of running the [=write a chunk=] algorithm with |stream| and |chunk|.
 1. Let |closeAlgorithm| be these steps:
    1. Let |closeResult| be [=a new promise=].
-   1. Run these steps [=in parallel=]:
-      1. Let |access| be the result of running |file|'s [=file system entry/query access=] given "`readwrite`".
+   1. [=Enqueue the following steps=] to the [=file system queue=]:
+      1. Let |access| be the result of running |file|'s
+         [=file system entry/query access=] given "`readwrite`".
       1. If |access| is not "{{PermissionState/granted}}",
          [=/reject=] |closeResult| with a "{{NotAllowedError}}" {{DOMException}}
-         and abort.
+         and abort these steps.
+
       1. Run [=implementation-defined=] malware scans and safe browsing checks.
-         If these checks fail, [=/reject=] |closeResult| with an "{{AbortError}}" {{DOMException}} and abort.
-      1. Set |stream|.[=FileSystemWritableFileStream/[[file]]=]'s [=file entry/binary data=] to |stream|.[=[[buffer]]=].
-         If that throws an exception, [=/reject=] |closeResult| with that exception and abort.
+         If these checks fail, [=/reject=] |closeResult| with an
+         "{{AbortError}}" {{DOMException}} and abort these steps.
+      1. Set |stream|'s [=FileSystemWritableFileStream/[[file]]=]'s
+         [=file entry/binary data=] to |stream|'s [=[[buffer]]=].
+         If that throws an exception, [=/reject=] |closeResult| with that
+         exception and abort these steps.
 
-         Note: It is expected that this atomically updates the contents of the file on disk
-         being written to.
+         Note: It is expected that this atomically updates the contents of the
+         file on disk being written to.
 
-      1. Let |onLockReleasedAlgorithm| be this step: [=/Resolve=] |closeResult| with `undefined`.
-      1. [=file entry/lock/release|Release the lock=] on |stream|'s
-         [=FileSystemWritableFileStream/[[file]]=] with |onLockReleasedAlgorithm|.
+      1. [=file entry/lock/release|Release the lock=] on
+         |stream|'s [=FileSystemWritableFileStream/[[file]]=].
+      1. [=/Resolve=] |closeResult| with `undefined`.
+
    1. Return |closeResult|.
-1. Let |abortAlgorithm| be this step: [=file entry/lock/release|release the lock=] on
-   |stream|.[=FileSystemWritableFileStream/[[file]]=].
+1. Let |abortAlgorithm| be these steps:
+   1. [=enqueue steps|Enqueue this step=] to the [=file system queue=]:
+     1. [=file entry/lock/release|release the lock=] on
+        |stream|'s [=FileSystemWritableFileStream/[[file]]=].
 1. Let |highWaterMark| be 1.
 1. Let |sizeAlgorithm| be an algorithm that returns `1`.
 1. [=WritableStream/Set up=] |stream| with <a for="WritableStream/set up"><var
@@ -1515,10 +1524,11 @@ The <dfn method for=FileSystemSyncAccessHandle>close()</dfn> method steps are:
 1. If [=this=]'s [=[[state]]=] is "`closed`", return.
 1. Set [=this=]'s [=[[state]]=] to "`closed`".
 1. Set |lockReleased| to false.
-1. Let |onLockReleasedAlgorithm| be this step: Set |lockReleased| to true.
-1. [=file entry/lock/release|Release the lock=] on
-   [=this=]'s [=FileSystemSyncAccessHandle/[[file]]=] with |onLockReleasedAlgorithm|.
-1. [=Pause=] until |lockReleased| is set to true.
+1. Let |file| be [=this=]'s [=FileSystemSyncAccessHandle/[[file]]=].
+1. [=Enqueue the following steps=] to the [=file system queue=]:
+  1. [=file entry/lock/release|Release the lock=] on |file|.
+  1. Set |lockReleased| to true.
+1. [=Pause=] until |lockReleased| is true.
 
 Note: This method does not guarantee that all file modifications will be
 immediately reflected in the underlying storage device. Call the

--- a/index.bs
+++ b/index.bs
@@ -95,9 +95,10 @@ It has the following [=struct/items=]:
 [=permission request algorithm=] may throw, [=/file system entry=]'s
 [=file system entry/query access=] and [=file system entry/request access=]
 algorithms must run [=in parallel=] on the [=file system queue=] and are
-therefore not allowed to throw. Instead, the caller is expected to [=/reject=]
-as appropriate should these algorithms return an
-[=file system access result/error name=] other than « the empty string ».
+therefore not allowed to throw. Instead, the caller is expected to
+[=queue a storage task=] to [=/reject=], as appropriate,
+should these algorithms return an [=file system access result/error name=]
+other than « the empty string ».
 
 Note: Implementations that only implement this specification and not dependent
 specifications do not need to bother implementing [=/file system entry=]'s

--- a/index.bs
+++ b/index.bs
@@ -1519,8 +1519,10 @@ The <dfn method for=FileSystemSyncAccessHandle>close()</dfn> method steps are:
 
 1. If [=this=]'s [=[[state]]=] is "`closed`", return.
 1. Set [=this=]'s [=[[state]]=] to "`closed`".
+1. Let |onLockReleasedAlgorithm| be an algorithm that does nothing.
 1. [=file entry/lock/release|Release the lock=] on
-   [=this=]'s [=FileSystemSyncAccessHandle/[[file]]=].
+   [=this=]'s [=FileSystemSyncAccessHandle/[[file]]=] with |onLockReleasedAlgorithm|.
+1. Wait for |onLockReleasedAlgorithm| to run.
 
 Note: This method does not guarantee that all file modifications will be
 immediately reflected in the underlying storage device. Call the

--- a/index.bs
+++ b/index.bs
@@ -107,18 +107,18 @@ To <dfn for="file entry/lock">take</dfn> a [=file entry/lock=] with a |value| of
 1. If |value| is "`exclusive`":
    1. If |lock| is "`open`":
      1. Set lock to "`taken-exclusive`".
-     1. Return a value of "`success`".
+     1. Return "`success`".
 1. If |value| is "`shared`":
    1. If |lock| is "`open`":
      1. Set |lock| to "`taken-shared`".
      1. Set |count| to 1.
-     1. Return a value of "`success`".
+     1. Return "`success`".
    1. Otherwise, if |lock| is "`taken-shared`":
      1. Increase |count| by 1.
-     1. Return a value of "`success`".
-1. Return a value of "`failure`".
+     1. Return "`success`".
+1. Return "`failure`".
 
-Note: These steps must be run on the [=file system queue=].
+Note: These steps have to be run on the [=file system queue=].
 
 </div>
 
@@ -133,7 +133,7 @@ To <dfn for="file entry/lock">release</dfn> a [=file entry/lock=] on a given
   1. If |count| is 0, set |lock| to "`open`".
 1. Otherwise, set |lock| to "`open`".
 
-Note: These steps must be run on the [=file system queue=].
+Note: These steps have to be run on the [=file system queue=].
 
 </div>
 
@@ -504,7 +504,8 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method 
 1. Let |result| be [=a new promise=].
 1. Let |locator| be [=this=]'s [=FileSystemHandle/locator=].
 1. Let |realm| be [=this=]'s [=relevant Realm=].
-1. [=Enqueue the following steps=] to the [=file system queue=]:
+1. [=Queue a storage task=] with [=this=]'s [=relevant global object=] to
+   [=enqueue the following steps=] to the [=file system queue=]:
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
   1. Let |access| be the result of running |entry|'s
      [=file system entry/request access=] given "`readwrite`".

--- a/index.bs
+++ b/index.bs
@@ -61,16 +61,31 @@ different storage mechanism with a different API for such files. The entry point
 
 A <dfn export id="entry">file system entry</dfn> is either a [=file entry=] or a [=directory entry=].
 
-Each [=/file system entry=] has an associated <dfn for="file system entry" id=entry-query-access>query access</dfn> algorithm, which takes "`read`"
-or "`readwrite`" <var ignore>mode</var> and returns a {{PermissionState}}. Unless specified
-otherwise it returns "{{PermissionState/denied}}". The algorithm is allowed to throw.
+Each [=/file system entry=] has an associated
+<dfn for="file system entry" id=entry-query-access>query access</dfn>
+algorithm, which takes "`read`" or "`readwrite`" <var ignore>mode</var> and
+returns either a {{PermissionState}} or an [=exception/error name=] that must be
+listed in the [=error names table=].
+Unless specified otherwise it returns "{{PermissionState/denied}}".
 
-Each [=/file system entry=] has an associated <dfn for="file system entry" id=entry-request-access>request access</dfn> algorithm, which takes
-"`read`" or "`readwrite`" <var ignore>mode</var> and returns a {{PermissionState}}. Unless specified
-otherwise it returns "{{PermissionState/denied}}". The algorithm is allowed to throw.
+Each [=/file system entry=] has an associated
+<dfn for="file system entry" id=entry-request-access>request access</dfn>
+algorithm, which takes "`read`" or "`readwrite`" <var ignore>mode</var> and
+returns either a {{PermissionState}} or an [=exception/error name=] that must be
+listed in the [=error names table=].
+Unless specified otherwise it returns "{{PermissionState/denied}}".
 
-Note: Implementations that only implement this specification and not dependent specifications do not
-need to bother implementing [=/file system entry=]'s [=file system entry/query access=] and [=file system entry/request access=].
+<p class=warning> Dependent specifications may consider this API a
+[=powerful feature=]. However, unlike other [=powerful features=] whose
+[=permission request algorithm=] may throw, [=/file system entry=]'s
+[=file system entry/query access=] and [=file system entry/request access=]
+algorithms must run [=in parallel=] on the [=file system queue=] and are
+therefore not allowed to throw. Instead, the caller is expected to [=/reject=]
+as appropriate should these algorithms return an [=exception/error name=].
+
+Note: Implementations that only implement this specification and not dependent
+specifications do not need to bother implementing [=/file system entry=]'s
+[=file system entry/query access=] and [=file system entry/request access=].
 
 Issue(101): Make access check algorithms associated with a FileSystemHandle.
 
@@ -504,31 +519,33 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method 
 1. Let |result| be [=a new promise=].
 1. Let |locator| be [=this=]'s [=FileSystemHandle/locator=].
 1. Let |realm| be [=this=]'s [=relevant Realm=].
-1. [=Queue a storage task=] with [=this=]'s [=relevant global object=] to
-   [=enqueue the following steps=] to the [=file system queue=]:
+1. Let |global| be [=this=]'s [=relevant global object=].
+1. [=Enqueue the following steps=] to the [=file system queue=]:
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
   1. Let |access| be the result of running |entry|'s
      [=file system entry/request access=] given "`readwrite`".
-     If that throws an exception, [=reject=] |result| with that exception and
-     abort these steps.
-  1. If |access| is not "{{PermissionState/granted}}",
-     [=reject=] |result| with a "{{NotAllowedError}}" {{DOMException}} and
-     abort these steps.
+  1. If |access| is not "{{PermissionState/granted}}":
+    1. Set |requestAccessError| to |access| if |access| is an
+       [=exception/error name=]; otherwise, "{{NotAllowedError}}".
+    1. [=Queue a storage task=] with |global| to [=/reject=] |result| with a
+       |requestAccessError| {{DOMException}} and abort these steps.
 
-  1. If |entry| is `null`, [=/reject=] |result| with a
-     "{{NotFoundError}}" {{DOMException}} and abort.
+  1. If |entry| is `null`, [=queue a storage task=] with |global| to [=/reject=]
+     |result| with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
   1. [=Assert=]: |entry| is a [=file entry=].
 
   1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
      with "`shared`" on |entry|.
-  1. If |lockResult| is "`failure`", [=reject=] |result| with a
+  1. If |lockResult| is "`failure`", [=queue a storage task=] with |global| to
+     [=/reject=] |result| with a
      "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
 
-  1. Let |stream| be the result of <a>creating a new `FileSystemWritableFileStream`</a>
-     for |entry| in |realm|.
-  1. If |options|'s {{FileSystemCreateWritableOptions/keepExistingData}} is true:
-     1. Set |stream|'s [=[[buffer]]=] to a copy of |entry|'s [=file entry/binary data=].
-  1. [=/Resolve=] |result| with |stream|.
+  1. [=Queue a storage task=] with |global| to run these steps:
+    1. Let |stream| be the result of <a>creating a new `FileSystemWritableFileStream`</a>
+       for |entry| in |realm|.
+    1. If |options|'s {{FileSystemCreateWritableOptions/keepExistingData}} is true:
+       1. Set |stream|'s [=[[buffer]]=] to a copy of |entry|'s [=file entry/binary data=].
+    1. [=/Resolve=] |result| with |stream|.
 
 1. Return |result|.
 
@@ -562,31 +579,36 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method s
 1. Let |result| be [=a new promise=].
 1. Let |locator| be [=this=]'s [=FileSystemHandle/locator=].
 1. Let |realm| be [=this=]'s [=relevant Realm=].
+1. Let |global| be [=this=]'s [=relevant global object=].
 1. [=Enqueue the following steps=] to the [=file system queue=]:
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
   1. Let |access| be the result of running |entry|'s
      [=file system entry/request access=] given "`readwrite`".
-     If that throws an exception, [=reject=] |result| with that exception and
-     abort these steps.
-  1. If |access| is not "{{PermissionState/granted}}", [=reject=] |result| with
-     a "{{NotAllowedError}}" {{DOMException}} and abort these steps.
+  1. If |access| is not "{{PermissionState/granted}}":
+    1. Set |requestAccessError| to |access| if |access| is an
+       [=exception/error name=]; otherwise, "{{NotAllowedError}}".
+    1. [=Queue a storage task=] with |global| to [=/reject=] |result| with a
+       |requestAccessError| {{DOMException}} and abort these steps.
 
-  1. If |entry| is `null`, [=/reject=] |result| with a
-     "{{NotFoundError}}" {{DOMException}} and abort.
+  1. If |entry| is `null`, [=queue a storage task=] with |global| to [=/reject=]
+     |result| with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
   1. [=Assert=]: |entry| is a [=file entry=].
 
-  1. If |entry| does not represent a [=/file system entry=] in an [=origin private file system=],
-     [=reject=] |result| with an "{{InvalidStateError}}" {{DOMException}} and
+  1. If |entry| does not represent a [=/file system entry=] in an
+     [=origin private file system=], [=queue a storage task=] with |global| to
+     [=/reject=] |result| with an "{{InvalidStateError}}" {{DOMException}} and
      abort these steps.
 
   1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
      with "`exclusive`" on |entry|.
-  1. If |lockResult| is "`failure`", [=reject=] |result| with a
+  1. If |lockResult| is "`failure`", [=queue a storage task=] with |global| to
+     [=/reject=] |result| with a
      "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
 
-  1. Let |handle| be the result of <a>creating a new `FileSystemSyncAccessHandle`</a>
-     for |entry| in |realm|.
-  1. [=/Resolve=] |result| with |handle|.
+  1. [=Queue a storage task=] with |global| to run these steps:
+    1. Let |handle| be the result of <a>creating a new `FileSystemSyncAccessHandle`</a>
+       for |entry| in |realm|.
+    1. [=/Resolve=] |result| with |handle|.
 
 1. Return |result|.
 
@@ -707,7 +729,7 @@ and its async iterator |iterator|:
    [=file system entry/query access=] given "`read`".
 
 1. If |access| is not "{{PermissionState/granted}}",
-   [=reject=] |promise| with a "{{NotAllowedError}}" {{DOMException}} and
+   [=/reject=] |promise| with a "{{NotAllowedError}}" {{DOMException}} and
    return |promise|.
 
 1. Let |child| be a [=/file system entry=] in |directory|'s [=directory entry/children=],
@@ -774,7 +796,7 @@ The <dfn method for=FileSystemDirectoryHandle>getFileHandle(|name|, |options|)</
   1. If |options|.{{FileSystemGetFileOptions/create}} is true:
     1. Let |access| be the result of running |entry|'s
        [=file system entry/request access=] given "`readwrite`".
-       If that throws an exception, [=reject=] |result| with that exception and abort.
+       If that throws an exception, [=/reject=] |result| with that exception and abort.
   1. Otherwise:
     1. Let |access| be the result of running |entry|'s
        [=file system entry/query access=] given "`read`".
@@ -848,7 +870,7 @@ The <dfn method for=FileSystemDirectoryHandle>getDirectoryHandle(|name|, |option
   1. If |options|.{{FileSystemGetDirectoryOptions/create}} is true:
     1. Let |access| be the result of running |entry|'s
        [=file system entry/request access=] given "`readwrite`".
-       If that throws an exception, [=reject=] |result| with that exception and abort.
+       If that throws an exception, [=/reject=] |result| with that exception and abort.
   1. Otherwise:
     1. Let |access| be the result of running |entry|'s
        [=file system entry/query access=] given "`read`".
@@ -915,7 +937,7 @@ The <dfn method for=FileSystemDirectoryHandle>removeEntry(|name|, |options|)</df
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
   1. Let |access| be the result of running |entry|'s
      [=file system entry/request access=] given "`readwrite`".
-     If that throws an exception, [=reject=] |result| with that exception and abort.
+     If that throws an exception, [=/reject=] |result| with that exception and abort.
   1. If |access| is not "{{PermissionState/granted}}",
      [=/reject=] |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
 
@@ -1065,24 +1087,29 @@ given a [=file entry=] |file| in a [=/Realm=] |realm|:
    1. [=Enqueue the following steps=] to the [=file system queue=]:
       1. Let |access| be the result of running |file|'s
          [=file system entry/query access=] given "`readwrite`".
-      1. If |access| is not "{{PermissionState/granted}}",
-         [=/reject=] |closeResult| with a "{{NotAllowedError}}" {{DOMException}}
-         and abort these steps.
+      1. If |access| is not "{{PermissionState/granted}}":
+         1. Set |requestAccessError| to |access| if |access| is an
+            [=exception/error name=]; otherwise, "{{NotAllowedError}}".
+         1. [=Queue a storage task=] with |file|'s [=relevant global object=] to
+            [=/reject=] |closeResult| with a
+            |requestAccessError| {{DOMException}} and abort these steps.
 
-      1. Run [=implementation-defined=] malware scans and safe browsing checks.
-         If these checks fail, [=/reject=] |closeResult| with an
-         "{{AbortError}}" {{DOMException}} and abort these steps.
-      1. Set |stream|'s [=FileSystemWritableFileStream/[[file]]=]'s
-         [=file entry/binary data=] to |stream|'s [=[[buffer]]=].
-         If that throws an exception, [=/reject=] |closeResult| with that
-         exception and abort these steps.
+      1. [=Queue a storage task=] with |file|'s [=relevant global object=]
+         to run these steps:
+        1. Run [=implementation-defined=] malware scans and safe browsing checks.
+           If these checks fail, [=/reject=] |closeResult| with an
+           "{{AbortError}}" {{DOMException}} and abort these steps.
+        1. Set |stream|'s [=FileSystemWritableFileStream/[[file]]=]'s
+           [=file entry/binary data=] to |stream|'s [=[[buffer]]=].
+           If that throws an exception, [=/reject=] |closeResult| with that
+           exception and abort these steps.
 
-         Note: It is expected that this atomically updates the contents of the
-         file on disk being written to.
+           Note: It is expected that this atomically updates the contents of the
+           file on disk being written to.
 
-      1. [=file entry/lock/release|Release the lock=] on
-         |stream|'s [=FileSystemWritableFileStream/[[file]]=].
-      1. [=/Resolve=] |closeResult| with `undefined`.
+        1. [=file entry/lock/release|Release the lock=] on
+           |stream|'s [=FileSystemWritableFileStream/[[file]]=].
+        1. [=/Resolve=] |closeResult| with `undefined`.
 
    1. Return |closeResult|.
 1. Let |abortAlgorithm| be these steps:

--- a/index.bs
+++ b/index.bs
@@ -64,16 +64,31 @@ A <dfn export id="entry">file system entry</dfn> is either a [=file entry=] or a
 Each [=/file system entry=] has an associated
 <dfn for="file system entry" id=entry-query-access>query access</dfn>
 algorithm, which takes "`read`" or "`readwrite`" <var ignore>mode</var> and
-returns either a {{PermissionState}} or an [=exception/error name=] that must be
-listed in the [=error names table=].
-Unless specified otherwise it returns "{{PermissionState/denied}}".
+returns a [=/file system access result=].
+Unless specified otherwise it returns a [=/file system access result=] with a
+[=file system access result/permission state=] of "{{PermissionState/denied}}"
+and with a [=file system access result/error name=] of « the empty string ».
 
 Each [=/file system entry=] has an associated
 <dfn for="file system entry" id=entry-request-access>request access</dfn>
 algorithm, which takes "`read`" or "`readwrite`" <var ignore>mode</var> and
-returns either a {{PermissionState}} or an [=exception/error name=] that must be
-listed in the [=error names table=].
-Unless specified otherwise it returns "{{PermissionState/denied}}".
+returns a [=/file system access result=].
+Unless specified otherwise it returns a [=/file system access result=] with a
+[=file system access result/permission state=] of "{{PermissionState/denied}}"
+and with a [=file system access result/error name=] of « the empty string ».
+
+A <dfn export>file system access result</dfn> is a [=struct=] encapsulating the
+result of [=file system entry/query access|querying=] or
+[=file system entry/request access|requesting=] access to the file system.
+It has the following [=struct/items=]:
+
+: <dfn for="file system access result">permission state</dfn>
+:: A {{PermissionState}}
+: <dfn for="file system access result">error name</dfn>
+:: A [=string=] which must be either « the empty string » or an
+   [=exception/error name=] listed in the [=error names table=].
+   If [=file system access result/permission state=] is
+   "{{PermissionState/granted}}" this must be « the empty string »
 
 <p class=warning> Dependent specifications may consider this API a
 [=powerful feature=]. However, unlike other [=powerful features=] whose
@@ -81,7 +96,8 @@ Unless specified otherwise it returns "{{PermissionState/denied}}".
 [=file system entry/query access=] and [=file system entry/request access=]
 algorithms must run [=in parallel=] on the [=file system queue=] and are
 therefore not allowed to throw. Instead, the caller is expected to [=/reject=]
-as appropriate should these algorithms return an [=exception/error name=].
+as appropriate should these algorithms return an
+[=file system access result/error name=] other than « the empty string ».
 
 Note: Implementations that only implement this specification and not dependent
 specifications do not need to bother implementing [=/file system entry=]'s
@@ -159,7 +175,7 @@ A <dfn export id=directory>directory entry</dfn> additionally consists of a [=/s
 <dfn for="directory entry">children</dfn>, which are themselves [=/file system entries=].
 Each member is either a [=/file entry=] or a [=/directory entry=].
 
-A [=/file system entry=] |entry| should be [=list/contained=] in the [=children=] of at most one
+A [=/file system entry=] |entry| should be [=list/contained=] in the [=directory entry/children=] of at most one
 [=directory entry=], and that directory entry is also known as |entry|'s
 <dfn export for="file system entry" id=entry-parent>parent</dfn>.
 A [=/file system entry=]'s [=file system entry/parent=] is null if no such directory entry exists.
@@ -170,7 +186,7 @@ parent while the other entry does not have a parent.
 
 [=/File system entries=] can (but don't have to) be backed by files on the host operating system's local file system,
 so it is possible for the [=binary data=], [=modification timestamp=],
-and [=children=] of entries to be modified by applications outside of this specification.
+and [=directory entry/children=] of entries to be modified by applications outside of this specification.
 Exactly how external changes are reflected in the data structures defined by this specification,
 as well as how changes made to the data structures defined here are reflected externally
 is left up to individual user-agent implementations.
@@ -185,22 +201,22 @@ To <dfn for="file system locator" id=locator-resolve>resolve</dfn> a
 [=/file system locator=] |child| relative to a [=directory locator=] |root|:
 
 1. Let |result| be [=a new promise=].
-1. Run these steps [=in parallel=]:
+1. [=Enqueue the following steps=] to the [=file system queue=]:
   1. If |child|'s [=FileSystemHandle/locator=]'s [=file system locator/root=]
      is not |root|'s [=FileSystemHandle/locator=]'s [=file system locator/root=],
-     [=/resolve=] |result| with null, and abort.
+     [=/resolve=] |result| with null, and abort these steps.
 
   1. Let |childPath| be |child|'s [=FileSystemHandle/locator=]'s [=file system locator/path=].
   1. Let |rootPath| be |root|'s [=FileSystemHandle/locator=]'s [=file system locator/path=].
   1. If |childPath| is [=the same path as=] |rootPath|,
-     [=/resolve=] |result| with « », and abort.
+     [=/resolve=] |result| with « », and abort these steps.
 
   1. If |rootPath|'s [=list/size=] is greater than |childPath|'s [=list/size=],
-     [=/resolve=] |result| with null, and abort.
+     [=/resolve=] |result| with null, and abort these steps.
 
   1. [=list/For each=] |index| of |rootPath|'s [=list/indices=]:
     1. If |rootPath|.\[[|index|]] is not |childPath|.\[[|index|]], then
-       [=/resolve=] |result| with null, and abort.
+       [=/resolve=] |result| with null, and abort these steps.
 
   1. Let |relativePath| be « ».
   1. [=list/For each=] |index| of [=the range=] from |rootPath|'s [=list/size=]
@@ -373,7 +389,7 @@ The <dfn method for=FileSystemHandle>isSameEntry(|other|)</dfn> method steps are
 
 1. Let |realm| be [=this=]'s [=relevant Realm=].
 1. Let |p| be [=a new promise=] in |realm|.
-1. Run these steps [=in parallel=]:
+1. [=Enqueue the following steps=] to the [=file system queue=]:
   1. If [=this=]'s [=FileSystemHandle/locator=] is
      [=the same locator as=] |other|'s [=FileSystemHandle/locator=],
      [=/resolve=] |p| with true.
@@ -452,27 +468,35 @@ The <dfn method for=FileSystemFileHandle>getFile()</dfn> method steps are:
 
 1. Let |result| be [=a new promise=].
 1. Let |locator| be [=this=]'s [=FileSystemHandle/locator=].
-1. Run these steps [=in parallel=]:
+1. Let |global| be [=this=]'s [=relevant global object=].
+1. [=Enqueue the following steps=] to the [=file system queue=]:
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
-  1. Let |access| be the result of running |entry|'s
+  1. Let |accessResult| be the result of running |entry|'s
      [=file system entry/query access=] given "`read`".
-  1. If |access| is not "{{PermissionState/granted}}",
-     [=/reject=] |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
 
-  1. If |entry| is null, [=/reject=] |result| with a
-     "{{NotFoundError}}" {{DOMException}} and abort.
-  1. [=Assert=]: |entry| is a [=file entry=].
+  1. [=Queue a storage task=] with |global| to run these steps:
+    1. If |accessResult|'s [=file system access result/permission state=]
+       is not "{{PermissionState/granted}}":
+      1. Set |accessErrorName| to |accessResult|'s
+         [=file system access result/error name=] if it is not
+         « the empty string »; otherwise "{{NotAllowedError}}".
+      1. [=/Reject=] |result| with an |accessErrorName| {{DOMException}} and
+         abort these steps.
 
-  1. Let |f| be a new {{File}}.
-  1. Set |f|'s <a spec=FileAPI>snapshot state</a> to the current state of |entry|.
-  1. Set |f|'s underlying byte sequence to a copy of |entry|'s [=binary data=].
-  1. Set |f|.{{File/name}} to |entry|'s [=file system entry/name=].
-  1. Set |f|.{{File/lastModified}} to |entry|'s [=file entry/modification timestamp=].
-  1. Set |f|.{{Blob/type}} to an [=implementation-defined=] value, based on for example |entry|'s [=file system entry/name=] or its file extension.
+    1. If |entry| is null, [=/reject=] |result| with a
+       "{{NotFoundError}}" {{DOMException}} and abort these steps.
+    1. [=Assert=]: |entry| is a [=file entry=].
 
-     Issue: The reading and snapshotting behavior needs to be better specified in the [[FILE-API]] spec,
-     for now this is kind of hand-wavy.
-  1. [=/Resolve=] |result| with |f|.
+    1. Let |f| be a new {{File}}.
+    1. Set |f|'s <a spec=FileAPI>snapshot state</a> to the current state of |entry|.
+    1. Set |f|'s underlying byte sequence to a copy of |entry|'s [=binary data=].
+    1. Set |f|.{{File/name}} to |entry|'s [=file system entry/name=].
+    1. Set |f|.{{File/lastModified}} to |entry|'s [=file entry/modification timestamp=].
+    1. Set |f|.{{Blob/type}} to an [=implementation-defined=] value, based on for example |entry|'s [=file system entry/name=] or its file extension.
+
+       Issue: The reading and snapshotting behavior needs to be better specified in the [[FILE-API]] spec,
+       for now this is kind of hand-wavy.
+    1. [=/Resolve=] |result| with |f|.
 1. Return |result|.
 
 </div>
@@ -522,13 +546,15 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method 
 1. Let |global| be [=this=]'s [=relevant global object=].
 1. [=Enqueue the following steps=] to the [=file system queue=]:
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
-  1. Let |access| be the result of running |entry|'s
+  1. Let |accessResult| be the result of running |entry|'s
      [=file system entry/request access=] given "`readwrite`".
-  1. If |access| is not "{{PermissionState/granted}}":
-    1. Set |requestAccessError| to |access| if |access| is an
-       [=exception/error name=]; otherwise, "{{NotAllowedError}}".
-    1. [=Queue a storage task=] with |global| to [=/reject=] |result| with a
-       |requestAccessError| {{DOMException}} and abort these steps.
+  1. If |accessResult|'s [=file system access result/permission state=]
+     is not "{{PermissionState/granted}}":
+    1. Set |accessErrorName| to |accessResult|'s
+       [=file system access result/error name=] if it is not
+       « the empty string »; otherwise "{{NotAllowedError}}".
+    1. [=Queue a storage task=] with |global| to [=/reject=] |result| with an
+       |accessErrorName| {{DOMException}} and abort these steps.
 
   1. If |entry| is `null`, [=queue a storage task=] with |global| to [=/reject=]
      |result| with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
@@ -536,11 +562,11 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method 
 
   1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
      with "`shared`" on |entry|.
-  1. If |lockResult| is "`failure`", [=queue a storage task=] with |global| to
-     [=/reject=] |result| with a
-     "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
 
   1. [=Queue a storage task=] with |global| to run these steps:
+    1. If |lockResult| is "`failure`", [=/reject=] |result| with a
+       "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
+
     1. Let |stream| be the result of <a>creating a new `FileSystemWritableFileStream`</a>
        for |entry| in |realm|.
     1. If |options|'s {{FileSystemCreateWritableOptions/keepExistingData}} is true:
@@ -582,13 +608,15 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method s
 1. Let |global| be [=this=]'s [=relevant global object=].
 1. [=Enqueue the following steps=] to the [=file system queue=]:
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
-  1. Let |access| be the result of running |entry|'s
+  1. Let |accessResult| be the result of running |entry|'s
      [=file system entry/request access=] given "`readwrite`".
-  1. If |access| is not "{{PermissionState/granted}}":
-    1. Set |requestAccessError| to |access| if |access| is an
-       [=exception/error name=]; otherwise, "{{NotAllowedError}}".
-    1. [=Queue a storage task=] with |global| to [=/reject=] |result| with a
-       |requestAccessError| {{DOMException}} and abort these steps.
+  1. If |accessResult|'s [=file system access result/permission state=]
+     is not "{{PermissionState/granted}}":
+    1. Set |accessErrorName| to |accessResult|'s
+       [=file system access result/error name=] if it is not
+       « the empty string »; otherwise "{{NotAllowedError}}".
+    1. [=Queue a storage task=] with |global| to [=/reject=] |result| with an
+       |accessErrorName| {{DOMException}} and abort these steps.
 
   1. If |entry| is `null`, [=queue a storage task=] with |global| to [=/reject=]
      |result| with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
@@ -601,11 +629,11 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method s
 
   1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
      with "`exclusive`" on |entry|.
-  1. If |lockResult| is "`failure`", [=queue a storage task=] with |global| to
-     [=/reject=] |result| with a
-     "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
 
   1. [=Queue a storage task=] with |global| to run these steps:
+    1. If |lockResult| is "`failure`", [=/reject=] |result| with a
+       "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
+
     1. Let |handle| be the result of <a>creating a new `FileSystemSyncAccessHandle`</a>
        for |entry| in |realm|.
     1. [=/Resolve=] |result| with |handle|.
@@ -701,13 +729,17 @@ support for example recursive iteration.
 The [=asynchronous iterator initialization steps=] for a {{FileSystemDirectoryHandle}} |handle|
 and its async iterator |iterator| are:
 
-1. Let |entry| be the result of [=locating an entry=]
-   given |handle|'s [=FileSystemHandle/locator=].
-1. Let |access| be the result of running |entry|'s
-   [=file system entry/query access=] given "`read`".
-
-1. If |access| is not "{{PermissionState/granted}}",
-   [=throw=] a "{{NotAllowedError}}" {{DOMException}}.
+1. [=Enqueue the following steps=] to the [=file system queue=]:
+  1. Let |entry| be the result of [=locating an entry=]
+     given |handle|'s [=FileSystemHandle/locator=].
+  1. Let |accessResult| be the result of running |entry|'s
+     [=file system entry/query access=] given "`read`".
+  1. If |accessResult|'s [=file system access result/permission state=]
+     is not "{{PermissionState/granted}}":
+    1. Set |accessErrorName| to |accessResult|'s
+       [=file system access result/error name=] if it is not
+       « the empty string »; otherwise "{{NotAllowedError}}".
+    1. [=Throw=] an |accessErrorName| {{DOMException}}.
 
 1. Set |iterator|'s <dfn for="FileSystemDirectoryHandle-iterator">past results</dfn> to an empty [=/set=].
 
@@ -718,43 +750,54 @@ To [=get the next iteration result=] for a {{FileSystemDirectoryHandle}} |handle
 and its async iterator |iterator|:
 
 1. Let |promise| be [=a new promise=].
+1. [=Enqueue the following steps=] to the [=file system queue=]:
+  1. Let |directory| be the result of [=locating an entry=]
+     given |handle|'s [=FileSystemHandle/locator=].
+  1. Let |accessResult| be the result of running |directory|'s
+     [=file system entry/query access=] given "`read`".
 
-1. Let |directory| be the result of [=locating an entry=]
-   given |handle|'s [=FileSystemHandle/locator=].
-1. If |directory| is `null`, [=/reject=] |result| with a
-   "{{NotFoundError}}" {{DOMException}} and abort.
-  1. [=Assert=]: |directory| is a [=directory entry=].
+  1. [=Queue a storage task=] with |handle|'s [=relevant global object=] to
+     run these steps:
+    1. If |accessResult|'s [=file system access result/permission state=]
+       is not "{{PermissionState/granted}}":
+      1. Set |accessErrorName| to |accessResult|'s
+         [=file system access result/error name=] if it is not
+         « the empty string »; otherwise "{{NotAllowedError}}".
+      1. [=/Reject=] |promise| with an |accessErrorName| {{DOMException}}
+         and return |promise|.
 
-1. Let |access| be the result of running |directory|'s
-   [=file system entry/query access=] given "`read`".
+    1. If |directory| is `null`, [=/reject=] |result| with a
+       "{{NotFoundError}}" {{DOMException}} and abort these steps.
+      1. [=Assert=]: |directory| is a [=directory entry=].
 
-1. If |access| is not "{{PermissionState/granted}}",
-   [=/reject=] |promise| with a "{{NotAllowedError}}" {{DOMException}} and
-   return |promise|.
+    1. Let |child| be a [=/file system entry=] in
+       |directory|'s [=directory entry/children=], such that
+       |child|'s [=file system entry/name=] is not contained in
+       |iterator|'s [=past results=], or `null` if no such entry exists.
 
-1. Let |child| be a [=/file system entry=] in |directory|'s [=directory entry/children=],
-   such that |child|'s [=file system entry/name=] is not contained in |iterator|'s [=past results=],
-   or `null` if no such entry exists.
+       Note: This is intentionally very vague about the iteration order.
+       Different platforms and file systems provide different guarantees about
+       iteration order, and we want it to be possible to efficiently implement
+       this on all platforms. As such no guarantees are given about the exact
+       order in which elements are returned.
 
-   Note: This is intentionally very vague about the iteration order. Different platforms
-   and file systems provide different guarantees about iteration order, and we want it to
-   be possible to efficiently implement this on all platforms. As such no guarantees are given
-   about the exact order in which elements are returned.
+    1. If |child| is `null`, [=/resolve=] |promise| with `undefined` and
+       abort these steps.
 
-1. If |child| is `null`, then:
-  1. [=/Resolve=] |promise| with `undefined`.
-
-1. Otherwise:
-  1. [=set/Append=] |child|'s [=file system entry/name=] to |iterator|'s [=past results=].
-  1. If |child| is a [=file entry=]:
-    1. Let |result| be the result of <a>creating a child `FileSystemFileHandle`</a>
-       with |handle|'s [=FileSystemHandle/locator=] and
-       |child|'s [=file system entry/name=] in |handle|'s [=relevant Realm=].
-  1. Otherwise:
-    1. Let |result| be the result of <a>creating a child `FileSystemDirectoryHandle`</a>
-       with |handle|'s [=FileSystemHandle/locator=] and
-       |child|'s [=file system entry/name=] in |handle|'s [=relevant Realm=].
-  1. [=/Resolve=] |promise| with (|child|'s [=file system entry/name=], |result|).
+    1. [=set/Append=] |child|'s [=file system entry/name=] to
+       |iterator|'s [=past results=].
+    1. If |child| is a [=file entry=]:
+      1. Let |result| be the result of
+         <a>creating a child `FileSystemFileHandle`</a> with
+         |handle|'s [=FileSystemHandle/locator=] and
+         |child|'s [=file system entry/name=] in |handle|'s [=relevant Realm=].
+    1. Otherwise:
+      1. Let |result| be the result of
+         <a>creating a child `FileSystemDirectoryHandle`</a> with
+         |handle|'s [=FileSystemHandle/locator=] and
+         |child|'s [=file system entry/name=] in |handle|'s [=relevant Realm=].
+    1. [=/Resolve=] |promise| with
+       (|child|'s [=file system entry/name=], |result|).
 
 1. Return |promise|.
 
@@ -789,47 +832,58 @@ The <dfn method for=FileSystemDirectoryHandle>getFileHandle(|name|, |options|)</
 1. Let |result| be [=a new promise=].
 1. Let |realm| be [=this=]'s [=relevant Realm=].
 1. Let |locator| be [=this=]'s [=FileSystemHandle/locator=].
-1. Run these steps [=in parallel=]:
-  1. If |name| is not a [=valid file name=], [=/reject=] |result| with a {{TypeError}} and abort.
+1. Let |global| be [=this=]'s [=relevant global object=].
+1. [=Enqueue the following steps=] to the [=file system queue=]:
+  1. If |name| is not a [=valid file name=], [=queue a storage task=] with
+     |global| to [=/reject=] |result| with a {{TypeError}} and
+     abort these steps.
 
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
   1. If |options|.{{FileSystemGetFileOptions/create}} is true:
-    1. Let |access| be the result of running |entry|'s
+    1. Let |accessResult| be the result of running |entry|'s
        [=file system entry/request access=] given "`readwrite`".
-       If that throws an exception, [=/reject=] |result| with that exception and abort.
   1. Otherwise:
-    1. Let |access| be the result of running |entry|'s
+    1. Let |accessResult| be the result of running |entry|'s
        [=file system entry/query access=] given "`read`".
-  1. If |access| is not "{{PermissionState/granted}}",
-     [=/reject=] |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
 
-  1. If |entry| is `null`, [=/reject=] |result| with a
-     "{{NotFoundError}}" {{DOMException}} and abort.
-  1. [=Assert=]: |entry| is a [=directory entry=].
+  1. [=Queue a storage task=] with |global| to run these steps:
+    1. If |accessResult|'s [=file system access result/permission state=]
+       is not "{{PermissionState/granted}}":
+      1. Set |accessErrorName| to |accessResult|'s
+         [=file system access result/error name=] if it is not
+         « the empty string »; otherwise "{{NotAllowedError}}".
+      1. [=/Reject=] |result| with an |accessErrorName| {{DOMException}} and
+         abort these steps.
 
+    1. If |entry| is `null`, [=/reject=] |result| with a
+       "{{NotFoundError}}" {{DOMException}} and abort these steps.
+    1. [=Assert=]: |entry| is a [=directory entry=].
 
-  1. [=set/For each=] |child| of |entry|'s [=directory entry/children=]:
-    1. If |child|'s [=file system entry/name=] equals |name|:
-      1. If |child| is a [=directory entry=]:
-        1. [=/Reject=] |result| with a "{{TypeMismatchError}}" {{DOMException}} and abort.
-      1. [=/Resolve=] |result| with the result of
-         <a>creating a child `FileSystemFileHandle`</a> with |locator| and
-         |child|'s [=file system entry/name=] in |realm| and abort.
-  1. If |options|.{{FileSystemGetFileOptions/create}} is false:
-    1. [=/Reject=] |result| with a "{{NotFoundError}}" {{DOMException}} and abort.
-  1. Let |child| be a new [=file entry=] whose [=query access=] and [=request access=] algorithms
-     are those of |entry|.
-  1. Set |child|'s [=file system entry/name=] to |name|.
-  1. Set |child|'s [=binary data=] to an empty [=byte sequence=].
-  1. Set |child|'s [=modification timestamp=] to the current time.
-  1. [=set/Append=] |child| to |entry|'s [=directory entry/children=].
-  1. If creating |child| in the underlying file system throws an exception,
-     [=/reject=] |result| with that exception and abort.
+    1. [=set/For each=] |child| of |entry|'s [=directory entry/children=]:
+      1. If |child|'s [=file system entry/name=] equals |name|:
+        1. If |child| is a [=directory entry=]:
+          1. [=/Reject=] |result| with a
+             "{{TypeMismatchError}}" {{DOMException}} and abort these steps.
+        1. [=/Resolve=] |result| with the result of
+           <a>creating a child `FileSystemFileHandle`</a> with |locator| and
+           |child|'s [=file system entry/name=] in |realm| and
+           abort these steps.
+    1. If |options|.{{FileSystemGetFileOptions/create}} is false:
+      1. [=/Reject=] |result| with a "{{NotFoundError}}" {{DOMException}} and
+         abort these steps.
+    1. Let |child| be a new [=file entry=] whose [=query access=] and
+       [=request access=] algorithms are those of |entry|.
+    1. Set |child|'s [=file system entry/name=] to |name|.
+    1. Set |child|'s [=binary data=] to an empty [=byte sequence=].
+    1. Set |child|'s [=modification timestamp=] to the current time.
+    1. [=set/Append=] |child| to |entry|'s [=directory entry/children=].
+    1. If creating |child| in the underlying file system throws an exception,
+       [=/reject=] |result| with that exception and abort these steps.
 
-     Issue(11): Better specify what possible exceptions this could throw.
-  1. [=/Resolve=] |result| with the result of
-     <a>creating a child `FileSystemFileHandle`</a> with |locator| and
-     |child|'s [=file system entry/name=] in |realm|.
+       Issue(11): Better specify what possible exceptions this could throw.
+    1. [=/Resolve=] |result| with the result of
+       <a>creating a child `FileSystemFileHandle`</a> with |locator| and
+       |child|'s [=file system entry/name=] in |realm|.
 1. Return |result|.
 
 </div>
@@ -863,45 +917,57 @@ The <dfn method for=FileSystemDirectoryHandle>getDirectoryHandle(|name|, |option
 1. Let |result| be [=a new promise=].
 1. Let |realm| be [=this=]'s [=relevant Realm=].
 1. Let |locator| be [=this=]'s [=FileSystemHandle/locator=].
-1. Run these steps [=in parallel=]:
-  1. If |name| is not a [=valid file name=], [=/reject=] |result| with a {{TypeError}} and abort.
+1. Let |global| be [=this=]'s [=relevant global object=].
+1. [=Enqueue the following steps=] to the [=file system queue=]:
+  1. If |name| is not a [=valid file name=], [=queue a storage task=] with
+     |global| to [=/reject=] |result| with a {{TypeError}} and
+     abort these steps.
 
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
   1. If |options|.{{FileSystemGetDirectoryOptions/create}} is true:
-    1. Let |access| be the result of running |entry|'s
+    1. Let |accessResult| be the result of running |entry|'s
        [=file system entry/request access=] given "`readwrite`".
-       If that throws an exception, [=/reject=] |result| with that exception and abort.
   1. Otherwise:
-    1. Let |access| be the result of running |entry|'s
+    1. Let |accessResult| be the result of running |entry|'s
        [=file system entry/query access=] given "`read`".
-  1. If |access| is not "{{PermissionState/granted}}",
-     [=/reject=] |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
 
-  1. If |entry| is `null`, [=/reject=] |result| with a
-     "{{NotFoundError}}" {{DOMException}} and abort.
-  1. [=Assert=]: |entry| is a [=directory entry=].
+  1. [=Queue a storage task=] with |global| to run these steps:
+    1. If |accessResult|'s [=file system access result/permission state=]
+       is not "{{PermissionState/granted}}":
+      1. Set |accessErrorName| to |accessResult|'s
+         [=file system access result/error name=] if it is not
+         « the empty string »; otherwise "{{NotAllowedError}}".
+      1. [=/Reject=] |result| with an |accessErrorName| {{DOMException}} and
+         abort these steps.
 
-  1. [=set/For each=] |child| of |entry|'s [=directory entry/children=]:
-    1. If |child|'s [=file system entry/name=] equals |name|:
-      1. If |child| is a [=file entry=]:
-        1. [=/Reject=] |result| with a "{{TypeMismatchError}}" {{DOMException}} and abort.
-      1. [=/Resolve=] |result| with the result of
-         <a>creating a child `FileSystemDirectoryHandle`</a> with
-         |locator| and |child|'s [=file system entry/name=] in |realm| and abort.
-  1. If |options|.{{FileSystemGetFileOptions/create}} is false:
-    1. [=/Reject=] |result| with a "{{NotFoundError}}" {{DOMException}} and abort.
-  1. Let |child| be a new [=directory entry=] whose [=query access=] and [=request access=]
-     algorithms are those of |entry|.
-  1. Set |child|'s [=file system entry/name=] to |name|.
-  1. Set |child|'s [=directory entry/children=] to an empty [=/set=].
-  1. [=set/Append=] |child| to |entry|'s [=directory entry/children=].
-  1. If creating |child| in the underlying file system throws an exception,
-     [=/reject=] |result| with that exception and abort.
+    1. If |entry| is `null`, [=/reject=] |result| with a
+       "{{NotFoundError}}" {{DOMException}} and abort these steps.
+    1. [=Assert=]: |entry| is a [=directory entry=].
 
-     Issue(11): Better specify what possible exceptions this could throw.
-  1. [=/Resolve=] |result| with the result of
-     <a>creating a child `FileSystemDirectoryHandle`</a> with
-     |locator| and |child|'s [=file system entry/name=] in |realm|.
+    1. [=set/For each=] |child| of |entry|'s [=directory entry/children=]:
+      1. If |child|'s [=file system entry/name=] equals |name|:
+        1. If |child| is a [=file entry=]:
+          1. [=/Reject=] |result| with a
+             "{{TypeMismatchError}}" {{DOMException}} and abort these steps.
+        1. [=/Resolve=] |result| with the result of
+           <a>creating a child `FileSystemDirectoryHandle`</a> with
+           |locator| and |child|'s [=file system entry/name=] in |realm| and
+           abort these steps.
+    1. If |options|.{{FileSystemGetFileOptions/create}} is false:
+      1. [=/Reject=] |result| with a "{{NotFoundError}}" {{DOMException}} and
+         abort these steps.
+    1. Let |child| be a new [=directory entry=] whose [=query access=] and
+       [=request access=] algorithms are those of |entry|.
+    1. Set |child|'s [=file system entry/name=] to |name|.
+    1. Set |child|'s [=directory entry/children=] to an empty [=/set=].
+    1. [=set/Append=] |child| to |entry|'s [=directory entry/children=].
+    1. If creating |child| in the underlying file system throws an exception,
+       [=/reject=] |result| with that exception and abort these steps.
+
+       Issue(11): Better specify what possible exceptions this could throw.
+    1. [=/Resolve=] |result| with the result of
+       <a>creating a child `FileSystemDirectoryHandle`</a> with
+       |locator| and |child|'s [=file system entry/name=] in |realm|.
 1. Return |result|.
 
 </div>
@@ -931,36 +997,50 @@ The <dfn method for=FileSystemDirectoryHandle>removeEntry(|name|, |options|)</df
 
 1. Let |result| be [=a new promise=].
 1. Let |locator| be [=this=]'s [=FileSystemHandle/locator=].
-1. Run these steps [=in parallel=]:
-  1. If |name| is not a [=valid file name=], [=/reject=] |result| with a {{TypeError}} and abort.
+1. Let |global| be [=this=]'s [=relevant global object=].
+1. [=Enqueue the following steps=] to the [=file system queue=]:
+  1. If |name| is not a [=valid file name=], [=queue a storage task=] with
+     |global| to [=/reject=] |result| with a {{TypeError}} and
+     abort these steps.
 
   1. Let |entry| be the result of [=locating an entry=] given |locator|.
-  1. Let |access| be the result of running |entry|'s
+  1. Let |accessResult| be the result of running |entry|'s
      [=file system entry/request access=] given "`readwrite`".
-     If that throws an exception, [=/reject=] |result| with that exception and abort.
-  1. If |access| is not "{{PermissionState/granted}}",
-     [=/reject=] |result| with a "{{NotAllowedError}}" {{DOMException}} and abort.
 
-  1. If |entry| is `null`, [=/reject=] |result| with a
-     "{{NotFoundError}}" {{DOMException}} and abort.
-  1. [=Assert=]: |entry| is a [=directory entry=].
+  1. [=Queue a storage task=] with |global| to run these steps:
+    1. If |accessResult|'s [=file system access result/permission state=]
+       is not "{{PermissionState/granted}}":
+      1. Set |accessErrorName| to |accessResult|'s
+         [=file system access result/error name=] if it is not
+         « the empty string »; otherwise "{{NotAllowedError}}".
+      1. [=/Reject=] |result| with an |accessErrorName| {{DOMException}} and
+         abort these steps.
 
-  1. [=set/For each=] |child| of |entry|'s [=directory entry/children=]:
-    1. If |child|'s [=file system entry/name=] equals |name|:
-      1. If |child| is a [=directory entry=]:
-        1. If |child|'s [=directory entry/children=] is not [=set/is empty|empty=] and |options|.{{FileSystemRemoveOptions/recursive}} is false:
-          1. [=/Reject=] |result| with an "{{InvalidModificationError}}" {{DOMException}} and abort.
-      1. [=set/Remove=] |child| from |entry|'s [=directory entry/children=].
-      1. If removing |child| in the underlying file system throws an exception,
-         [=/reject=] |result| with that exception and abort.
+    1. If |entry| is `null`, [=/reject=] |result| with a
+       "{{NotFoundError}}" {{DOMException}} and abort these steps.
+    1. [=Assert=]: |entry| is a [=directory entry=].
 
-         Note: If {{FileSystemRemoveOptions/recursive}} is true, the removal can fail
-         non-atomically. Some files or directories might have been removed while other files
-         or directories still exist.
+    1. [=set/For each=] |child| of |entry|'s [=directory entry/children=]:
+      1. If |child|'s [=file system entry/name=] equals |name|:
+        1. If |child| is a [=directory entry=]:
+          1. If |child|'s [=directory entry/children=] is not
+             [=set/is empty|empty=] and
+             |options|.{{FileSystemRemoveOptions/recursive}} is false:
+            1. [=/Reject=] |result| with an
+               "{{InvalidModificationError}}" {{DOMException}} and
+               abort these steps.
+        1. [=set/Remove=] |child| from |entry|'s [=directory entry/children=].
+        1. If removing |child| in the underlying file system throws an
+           exception, [=/reject=] |result| with that exception and
+           abort these steps.
 
-         Issue(11): Better specify what possible exceptions this could throw.
-      1. [=/Resolve=] |result| with `undefined`.
-  1. [=/Reject=] |result| with a "{{NotFoundError}}" {{DOMException}}.
+           Note: If {{FileSystemRemoveOptions/recursive}} is true, the removal can fail
+           non-atomically. Some files or directories might have been removed while other files
+           or directories still exist.
+
+           Issue(11): Better specify what possible exceptions this could throw.
+        1. [=/Resolve=] |result| with `undefined`.
+    1. [=/Reject=] |result| with a "{{NotFoundError}}" {{DOMException}}.
 1. Return |result|.
 
 </div>
@@ -1085,17 +1165,19 @@ given a [=file entry=] |file| in a [=/Realm=] |realm|:
 1. Let |closeAlgorithm| be these steps:
    1. Let |closeResult| be [=a new promise=].
    1. [=Enqueue the following steps=] to the [=file system queue=]:
-      1. Let |access| be the result of running |file|'s
+      1. Let |accessResult| be the result of running |file|'s
          [=file system entry/query access=] given "`readwrite`".
-      1. If |access| is not "{{PermissionState/granted}}":
-         1. Set |requestAccessError| to |access| if |access| is an
-            [=exception/error name=]; otherwise, "{{NotAllowedError}}".
-         1. [=Queue a storage task=] with |file|'s [=relevant global object=] to
-            [=/reject=] |closeResult| with a
-            |requestAccessError| {{DOMException}} and abort these steps.
 
       1. [=Queue a storage task=] with |file|'s [=relevant global object=]
          to run these steps:
+        1. If |accessResult|'s [=file system access result/permission state=]
+           is not "{{PermissionState/granted}}":
+          1. Set |accessErrorName| to |accessResult|'s
+             [=file system access result/error name=] if it is not
+             « the empty string »; otherwise "{{NotAllowedError}}".
+          1. [=/Reject=] |closeResult| with an
+             |accessErrorName| {{DOMException}} and abort these steps.
+
         1. Run [=implementation-defined=] malware scans and safe browsing checks.
            If these checks fail, [=/reject=] |closeResult| with an
            "{{AbortError}}" {{DOMException}} and abort these steps.
@@ -1107,14 +1189,16 @@ given a [=file entry=] |file| in a [=/Realm=] |realm|:
            Note: It is expected that this atomically updates the contents of the
            file on disk being written to.
 
-        1. [=file entry/lock/release|Release the lock=] on
-           |stream|'s [=FileSystemWritableFileStream/[[file]]=].
-        1. [=/Resolve=] |closeResult| with `undefined`.
+        1. [=Enqueue the following steps=] to the [=file system queue=]:
+          1. [=file entry/lock/release|Release the lock=] on
+             |stream|'s [=FileSystemWritableFileStream/[[file]]=].
+          1. [=Queue a storage task=] with |file|'s [=relevant global object=]
+             to [=/resolve=] |closeResult| with `undefined`.
 
    1. Return |closeResult|.
 1. Let |abortAlgorithm| be these steps:
    1. [=enqueue steps|Enqueue this step=] to the [=file system queue=]:
-     1. [=file entry/lock/release|release the lock=] on
+     1. [=file entry/lock/release|Release the lock=] on
         |stream|'s [=FileSystemWritableFileStream/[[file]]=].
 1. Let |highWaterMark| be 1.
 1. Let |sizeAlgorithm| be an algorithm that returns `1`.
@@ -1136,18 +1220,28 @@ runs these steps:
 1. Let |input| be the result of [=converted to an IDL value|converting=] |chunk| to a {{FileSystemWriteChunkType}}.
    If this throws an exception, then return [=a promise rejected with=] that exception.
 1. Let |p| be [=a new promise=].
-1. Run these steps [=in parallel=]:
-   1. Let |access| be the result of running |stream|'s [=FileSystemWritableFileStream/[[file]]=]'s
-      [=file system entry/query access=] given "`readwrite`".
-   1. If |access| is not "{{PermissionState/granted}}",
-      [=/reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and abort.
-   1. Let |command| be |input|.{{WriteParams/type}} if |input| is a {{WriteParams}},
-      and {{WriteCommandType/"write"}} otherwise.
-   1. If |command| is {{WriteCommandType/"write"}}:
+1. [=Enqueue the following steps=] to the [=file system queue=]:
+  1. Let |accessResult| be the result of running
+     |stream|'s [=FileSystemWritableFileStream/[[file]]=]'s
+     [=file system entry/query access=] given "`readwrite`".
+
+  1. [=Queue a storage task=] with |stream|'s [=relevant global object=] to
+     run these steps:
+    1. If |accessResult|'s [=file system access result/permission state=]
+       is not "{{PermissionState/granted}}":
+      1. Set |accessErrorName| to |accessResult|'s
+         [=file system access result/error name=] if it is not
+         « the empty string »; otherwise "{{NotAllowedError}}".
+      1. [=/Reject=] |p| with an |accessErrorName| {{DOMException}} and
+         abort these steps.
+
+    1. Let |command| be |input|.{{WriteParams/type}} if |input| is a {{WriteParams}},
+       and {{WriteCommandType/"write"}} otherwise.
+    1. If |command| is {{WriteCommandType/"write"}}:
       1. Let |data| be |input|.{{WriteParams/data}} if |input| is a {{WriteParams}},
          and |input| otherwise.
       1. If |data| is `undefined`,
-         [=/reject=] |p| with a {{TypeError}} and abort.
+         [=/reject=] |p| with a {{TypeError}} and abort these steps.
       1. Let |writePosition| be |stream|.[=[[seekOffset]]=].
       1. If |input| is a {{WriteParams}} and |input|.{{WriteParams/position}} is not `undefined`,
          set |writePosition| to |input|.{{WriteParams/position}}.
@@ -1157,7 +1251,8 @@ runs these steps:
       1. Otherwise, if |data| is a {{Blob}}:
          1. Let |dataBytes| be the result of performing the
             <a spec=FileAPI>read operation</a> on |data|.
-            If this throws an exception, [=/reject=] |p| with that exception and abort.
+            If this throws an exception, [=/reject=] |p| with that exception
+            and abort these steps.
       1. Otherwise:
          1. [=Assert=]: |data| is a {{USVString}}.
          1. Let |dataBytes| be the result of [=UTF-8 encoding=] |data|.
@@ -1176,7 +1271,8 @@ runs these steps:
             |oldSize| - (|writePosition| + |data|.[=byte sequence/length=]) bytes of |stream|.[=[[buffer]]=].
       1. Set |stream|.[=[[buffer]]=] to the concatenation of |head|, |data| and |tail|.
       1. If the operations modifying |stream|.[=[[buffer]]=] in the previous steps failed
-         due to exceeding the [=storage quota=], [=/reject=] |p| with a "{{QuotaExceededError}}" {{DOMException}} and abort,
+         due to exceeding the [=storage quota=], [=/reject=] |p| with a
+         "{{QuotaExceededError}}" {{DOMException}} and abort these steps,
          leaving |stream|.[=[[buffer]]=] unmodified.
 
          Note: [=Storage quota=] only applies to files stored in the [=origin private file system=].
@@ -1184,22 +1280,22 @@ runs these steps:
          to runs out of disk space.
       1. Set |stream|.[=[[seekOffset]]=] to |writePosition| + |data|.[=byte sequence/length=].
       1. [=/Resolve=] |p|.
-   1. Otherwise, if |command| is {{WriteCommandType/"seek"}}:
+    1. Otherwise, if |command| is {{WriteCommandType/"seek"}}:
       1. If |chunk|.{{WriteParams/position}} is `undefined`,
-         [=/reject=] |p| with a {{TypeError}} and abort.
+         [=/reject=] |p| with a {{TypeError}} and abort these steps.
       1. Set |stream|.[=[[seekOffset]]=] to |chunk|.{{WriteParams/position}}.
       1. [=/Resolve=] |p|.
-   1. Otherwise, if |command| is {{WriteCommandType/"truncate"}}:
+    1. Otherwise, if |command| is {{WriteCommandType/"truncate"}}:
       1. If |chunk|.{{WriteParams/size}} is `undefined`,
-         [=/reject=] |p| with a {{TypeError}} and abort.
+         [=/reject=] |p| with a {{TypeError}} and abort these steps.
       1. Let |newSize| be |chunk|.{{WriteParams/size}}.
       1. Let |oldSize| be |stream|.[=[[buffer]]=]'s [=byte sequence/length=].
       1. If |newSize| is larger than |oldSize|:
          1. Set |stream|.[=[[buffer]]=] to a [=byte sequence=] formed by concating
             |stream|.[=[[buffer]]=] with a [=byte sequence=] containing |newSize|-|oldSize| `0x00` bytes.
          1. If the operation in the previous step failed due to exceeding the [=storage quota=],
-            [=/reject=] |p| with a "{{QuotaExceededError}}" {{DOMException}} and abort,
-            leaving |stream|.[=[[buffer]]=] unmodified.
+            [=/reject=] |p| with a "{{QuotaExceededError}}" {{DOMException}} and
+            abort these steps, leaving |stream|.[=[[buffer]]=] unmodified.
 
             Note: [=Storage quota=] only applies to files stored in the [=origin private file system=].
             However this operation could still fail for other files, for example if the disk being written
@@ -1603,8 +1699,12 @@ The <dfn method for=StorageManager>getDirectory()</dfn> method steps are:
    return [=a promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
 
 1. If |map|["root"] does not [=map/exist=]:
-  1. Let |dir| be a new [=directory entry=] whose [=query access=] and [=request access=] algorithms
-     always return "{{PermissionState/granted}}".
+  1. Let |dir| be a new [=directory entry=] whose [=query access=] and
+     [=request access=] algorithms always return
+     a [=/file system access result=]
+     with a [=file system access result/permission state=]
+     of "{{PermissionState/granted}}" and
+     with a [=file system access result/error name=] of « the empty string ».
   1. Set |dir|'s [=file system entry/name=] to the empty string.
   1. Set |dir|'s [=directory entry/children=] to an empty [=/set=].
   1. Set |map|["root"] to |dir|.

--- a/index.bs
+++ b/index.bs
@@ -95,8 +95,7 @@ a <dfn for="file entry">lock</dfn> (a string that may exclusively be "`open`", "
 and a <dfn for="file entry">shared lock count</dfn> (a number representing the number shared locks that are taken at a given point in time).
 
 The <dfn id="file-system-lock-queue">file system lock queue</dfn> is a
-[=parallel queue=] to be used for all <a for=/>tasks</a> involving a
-[=file entry/lock=].
+[=parallel queue=] to be used for all [=tasks=] involving a [=file entry/lock=].
 
 <div algorithm>
 To <dfn for="file entry/lock">take</dfn> a [=file entry/lock=] with a |value| of "`exclusive`" or "`shared`" on a given [=file entry=] |file|:

--- a/index.bs
+++ b/index.bs
@@ -100,8 +100,8 @@ result of [=starting a new parallel queue=]. This queue is to be used for all
 
 <div algorithm>
 To <dfn for="file entry/lock">take</dfn> a [=file entry/lock=] with a |value| of
-"`exclusive`" or "`shared`" on a given [=file entry=] |file|, with promise |p|,
-algorithm |onLockTakenAlgorithm|, and [=task source=] |replyTaskSource|:
+"`exclusive`" or "`shared`" on a given [=file entry=] |file| and with
+algorithm |resultAlgorithm|:
 
 1. [=Enqueue the following steps=] to the [=file system lock queue=]:
   1. Let |lock| be the |file|'s [=file entry/lock=].
@@ -109,26 +109,26 @@ algorithm |onLockTakenAlgorithm|, and [=task source=] |replyTaskSource|:
   1. If |value| is "`exclusive`":
      1. If |lock| is "`open`":
        1. Set lock to "`taken-exclusive`".
-       1. [=Queue a task=] to |replyTaskSource| to run |onLockTakenAlgorithm|
-          and return.
+       1. [=Queue a global task=] on the [=storage task source=] to run
+          |resultAlgorithm| with a value of "`success`" and return.
   1. If |value| is "`shared`":
      1. If |lock| is "`open`":
        1. Set |lock| to "`taken-shared`".
        1. Set |count| to 1.
-       1. [=Queue a task=] to |replyTaskSource| to run |onLockTakenAlgorithm|
-          and return.
+       1. [=Queue a global task=] on the [=storage task source=] to run
+          |resultAlgorithm| with a value of "`success`" and return.
      1. Otherwise, if |lock| is "`taken-shared`":
        1. Increase |count| by one.
-       1. [=Queue a task=] to |replyTaskSource| to run |onLockTakenAlgorithm|
-          and return.
-  1. [=Reject=] |p| with a "{{NoModificationAllowedError}}" {{DOMException}}.
+       1. [=Queue a global task=] on the [=storage task source=] to run
+          |resultAlgorithm| with a value of "`success`" and return.
+  1. [=Queue a global task=] on the [=storage task source=] to run
+     |resultAlgorithm| with a value of "`failure`" and return.
 
 </div>
 
 <div algorithm>
 To <dfn for="file entry/lock">release</dfn> a [=file entry/lock=] on a given
-[=file entry=] |file| with algorithm |onLockReleasedAlgorithm| and
-[=task source=] |replyTaskSource|:
+[=file entry=] |file| and with an optional algorithm |onLockReleasedAlgorithm|:
 
 1. [=Enqueue the following steps=] to the [=file system lock queue=]:
   1. Let |lock| be the |file|'s associated [=file entry/lock=].
@@ -137,8 +137,8 @@ To <dfn for="file entry/lock">release</dfn> a [=file entry/lock=] on a given
     1. Decrease |count| by one.
     1. If |count| is 0, set |lock| to "`open`".
   1. Otherwise, set |lock| to "`open`".
-  1. [=Queue a task=] to |replyTaskSource| to run |onLockReleasedAlgorithm|
-      and return.
+  1. If |onLockReleasedAlgorithm| was given, [=queue a global task=] on the
+     [=storage task source=] to run |onLockReleasedAlgorithm|.
 
 </div>
 
@@ -518,14 +518,17 @@ The <dfn method for=FileSystemFileHandle>createWritable(|options|)</dfn> method 
   1. If |entry| is `null`, [=/reject=] |result| with a
      "{{NotFoundError}}" {{DOMException}} and abort.
   1. [=Assert=]: |entry| is a [=file entry=].
-  1. Let |onLockTakenAlgorithm| be these steps:
+  1. Let |lockResultAlgorithm| be an algorithm which takes a |lockResult| and
+     runs these steps:
+    1. If |lockResult| is "`failure`", [=reject=] |result| with a
+       "{{NoModificationAllowedError}}" {{DOMException}} and abort.
     1. Let |stream| be the result of <a>creating a new `FileSystemWritableFileStream`</a>
        for |entry| in [=this=]'s [=relevant realm=].
     1. If |options|.{{FileSystemCreateWritableOptions/keepExistingData}} is true:
       1. Set |stream|.[=[[buffer]]=] to a copy of |entry|'s [=file entry/binary data=].
     1. [=/Resolve=] |result| with |stream|.
-  1. [=file entry/lock/take|Take a lock=] with "`shared`" on |entry| with
-     |result|, |onLockTakenAlgorithm|, and [=storage task source=].
+  1. [=file entry/lock/take|Take a lock=] with "`shared`" on |entry| and with
+     |lockResultAlgorithm|.
 1. Return |result|.
 
 </div>
@@ -571,11 +574,23 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method s
 
   1. If |entry| does not represent a [=/file system entry=] in an [=origin private file system=],
      [=reject=] |result| with an "{{InvalidStateError}}" {{DOMException}} and abort.
+<<<<<<< HEAD
   1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=] with "`exclusive`" on |entry|.
   1. If |lockResult| is false, [=reject=] |result| with a "{{NoModificationAllowedError}}" {{DOMException}} and abort.
   1. Let |handle| be the result of <a>creating a new `FileSystemSyncAccessHandle`</a>
      for |entry| in [=this=]'s [=relevant realm=].
   1. [=/Resolve=] |result| with |handle|.
+=======
+  1. Let |lockResultAlgorithm| be an algorithm which takes a |lockResult| and
+     runs these steps:
+     1. If |lockResult| is "`failure`", [=reject=] |result| with a
+       "{{NoModificationAllowedError}}" {{DOMException}} and abort.
+     1. Let |handle| be the result of <a>creating a new `FileSystemSyncAccessHandle`</a>
+        for |entry| in [=this=]'s [=relevant realm=].
+     1. [=/Resolve=] |result| with |handle|.
+  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
+     with "`exclusive`" on |entry| and with |lockResultAlgorithm|.
+>>>>>>> f840b90 (pass only one algorithm)
 1. Return |result|.
 
 </div>
@@ -1064,8 +1079,8 @@ given a [=file entry=] |file| in a [=/Realm=] |realm|:
          being written to.
 
       1. Let |onLockReleasedAlgorithm| be this step: [=/Resolve=] |closeResult| with `undefined`.
-      1. [=file entry/lock/release|Release the lock=] on |stream|'s [=FileSystemWritableFileStream/[[file]]=]
-         with |onLockReleasedAlgorithm|, and the currently running [=task=]'s' [=task source|source=].
+      1. [=file entry/lock/release|Release the lock=] on |stream|'s
+         [=FileSystemWritableFileStream/[[file]]=] with |onLockReleasedAlgorithm|.
    1. Return |closeResult|.
 1. Let |abortAlgorithm| be this step: [=file entry/lock/release|release the lock=] on
    |stream|.[=FileSystemWritableFileStream/[[file]]=].


### PR DESCRIPTION
Fixes #74 by specifying a parallel queue for all file system operations, not just locking (see https://github.com/whatwg/fs/pull/9/files#r1109679577)

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * WebKit
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * N/A (unless there's a way to deterministically test race conditions that I don't know about)
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: ...
   * Gecko: …
   * WebKit: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/95.html" title="Last updated on Jun 13, 2023, 4:32 PM UTC (ba5a295)">Preview</a> | <a href="https://whatpr.org/fs/95/8360b75...ba5a295.html" title="Last updated on Jun 13, 2023, 4:32 PM UTC (ba5a295)">Diff</a>