### PR TITLE
Editorial: Fix ambiguous link for directory entry children

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -135,7 +135,7 @@ A <dfn export id=directory>directory entry</dfn> additionally consists of a [=/s
 <dfn for="directory entry">children</dfn>, which are themselves [=/file system entries=].
 Each member is either a [=/file entry=] or a [=/directory entry=].
 
-A [=/file system entry=] |entry| should be [=list/contained=] in the [=children=] of at most one
+A [=/file system entry=] |entry| should be [=list/contained=] in the [=directory entry/children=] of at most one
 [=directory entry=], and that directory entry is also known as |entry|'s
 <dfn export for="file system entry" id=entry-parent>parent</dfn>.
 A [=/file system entry=]'s [=file system entry/parent=] is null if no such directory entry exists.
@@ -146,7 +146,7 @@ parent while the other entry does not have a parent.
 
 [=/File system entries=] can (but don't have to) be backed by files on the host operating system's local file system,
 so it is possible for the [=binary data=], [=modification timestamp=],
-and [=children=] of entries to be modified by applications outside of this specification.
+and [=directory entry/children=] of entries to be modified by applications outside of this specification.
 Exactly how external changes are reflected in the data structures defined by this specification,
 as well as how changes made to the data structures defined here are reflected externally
 is left up to individual user-agent implementations.


### PR DESCRIPTION
This fixes bikeshed [link error](https://speced.github.io/bikeshed/#ambi-for).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/117.html" title="Last updated on May 8, 2023, 11:11 PM UTC (98113d1)">Preview</a> | <a href="https://whatpr.org/fs/117/8360b75...98113d1.html" title="Last updated on May 8, 2023, 11:11 PM UTC (98113d1)">Diff</a>