### PR TITLE
Editorial: Fix broken link to DOMException names table

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -88,7 +88,7 @@ It has the following [=struct/items=]:
 :: A [=string=] which must be the empty string if
    [=file system access result/permission state=] is
    "{{PermissionState/granted}}"; otherwise an
-   [=DOMException/name=] listed in the [=`DOMException` names table=].
+   [=DOMException/name=] listed in the <a>`DOMException` names table</a>.
    It is expected that in most cases when
    [=file system access result/permission state=] is not
    "{{PermissionState/granted}}", this should be "{{NotAllowedError}}".


### PR DESCRIPTION
Using backticks is not supported within [=links=] 

Upstream PR to export the error names table is here: https://github.com/whatwg/webidl/pull/1325


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/135.html" title="Last updated on Jun 21, 2023, 7:17 AM UTC (fac2c1f)">Preview</a> | <a href="https://whatpr.org/fs/135/69c51d3...fac2c1f.html" title="Last updated on Jun 21, 2023, 7:17 AM UTC (fac2c1f)">Diff</a>