### PR TITLE
Meta: Fix an example in the FileSystemObserver explainer

### DIFF
--- a/proposals/FileSystemObserver.md
+++ b/proposals/FileSystemObserver.md
@@ -68,7 +68,7 @@ A `FileSystemObserver` allows changes to the file to be observed with much more 
 ```javascript
 // Same as above, but using the proposed FileSystemObserver
 
-const callback = (records, observer) => {
+const callback = async (records, observer) => {
   // Will be run when the observed file changes.
 
   // The change record includes a handle detailing which file has


### PR DESCRIPTION
An example in the FileSystemObserver explainer has a callback that uses the await operator but is not an async function. This makes it an async function.