### PR TITLE
Update non-normative text for DirectoryHandle's removeEntry()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -980,9 +980,9 @@ The <dfn method for=FileSystemDirectoryHandle>getDirectoryHandle(|name|, |option
      directory named |name|, this will attempt to delete that file or directory.
 
      Attempting to delete a file or directory that does not exist results in a promise
-     being rejected with a "NotFoundError" DOMException. Similarly, attempting to delete
-     a non-empty directory results in a promise being rejected with an
-     "InvalidModificationError" DOMException.
+     being rejected with a "NotFoundError" DOMException. Attempting to delete a non-empty
+     directory results in a promise being rejected with an "InvalidModificationError"
+     DOMException.
 
   : await |directoryHandle| . {{FileSystemDirectoryHandle/removeEntry()|removeEntry}}(|name|, { {{FileSystemRemoveOptions/recursive}}: true })
   :: Removes the [=/file system entry=] named |name| in the [=directory entry=]

--- a/index.bs
+++ b/index.bs
@@ -979,15 +979,17 @@ The <dfn method for=FileSystemDirectoryHandle>getDirectoryHandle(|name|, |option
      [=FileSystemHandle/locator=] contains a file named |name|, or an empty
      directory named |name|, this will attempt to delete that file or directory.
 
-     Attempting to delete a file or directory that does not exist is considered success,
-     while attempting to delete a non-empty directory will result in a promise rejection.
+     Attempting to delete a file or directory that does not exist will result in a promise
+     rejection with a "NotFoundError" DOMException. While attempting to delete a non-empty
+     directory will result in a promise rejection with an "InvalidModificationError" DOMException.
 
   : await |directoryHandle| . {{FileSystemDirectoryHandle/removeEntry()|removeEntry}}(|name|, { {{FileSystemRemoveOptions/recursive}}: true })
   :: Removes the [=/file system entry=] named |name| in the [=directory entry=]
      [=locate an entry|locatable=] by |directoryHandle|'s [=FileSystemHandle/locator=].
      If that entry is a directory, its contents will also be deleted recursively.
 
-     Attempting to delete a file or directory that does not exist is considered success.
+     Attempting to delete a file or directory that does not exist will result in a promise
+     rejection with a "NotFoundError" DOMException.
 </div>
 
 <div algorithm>
@@ -1758,6 +1760,7 @@ Marcos Cáceres,
 Martin Thomson,
 Olivier Yiptong,
 Philip Jägenstedt,
+Rahul Singh,
 Randell Jesup,
 Richard Stotz,
 Ruth John,

--- a/index.bs
+++ b/index.bs
@@ -979,17 +979,18 @@ The <dfn method for=FileSystemDirectoryHandle>getDirectoryHandle(|name|, |option
      [=FileSystemHandle/locator=] contains a file named |name|, or an empty
      directory named |name|, this will attempt to delete that file or directory.
 
-     Attempting to delete a file or directory that does not exist will result in a promise
-     rejection with a "NotFoundError" DOMException. While attempting to delete a non-empty
-     directory will result in a promise rejection with an "InvalidModificationError" DOMException.
+     Attempting to delete a file or directory that does not exist results in a promise
+     being rejected with a "NotFoundError" DOMException. Similarly, attempting to delete
+     a non-empty directory results in a promise being rejected with an
+     "InvalidModificationError" DOMException.
 
   : await |directoryHandle| . {{FileSystemDirectoryHandle/removeEntry()|removeEntry}}(|name|, { {{FileSystemRemoveOptions/recursive}}: true })
   :: Removes the [=/file system entry=] named |name| in the [=directory entry=]
      [=locate an entry|locatable=] by |directoryHandle|'s [=FileSystemHandle/locator=].
      If that entry is a directory, its contents will also be deleted recursively.
 
-     Attempting to delete a file or directory that does not exist will result in a promise
-     rejection with a "NotFoundError" DOMException.
+     Attempting to delete a file or directory that does not exist results in a promise
+     being rejected with a "NotFoundError" DOMException.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
This change updates only the non-normative section for
FileSystemDirectoryHandle's removeEntry() method.

It clarifies that the Promise is rejected with a "NotFoundError"
DOMException when an entry corresponding to the `name` parameter does
not exist.

Further, it adds that the Promise is rejected with an
"InvalidModificationError" DOMException when attempting to remove a
non-empty directory with the `recursive` option set to false.