### PR TITLE
Update QuotaExceededError usage

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1268,8 +1268,8 @@ runs these steps:
          |head|, |data| and |tail|.
       1. If the operations modifying |stream|'s [=[[buffer]]=] in the
          previous steps failed due to exceeding the [=storage quota=],
-         [=/reject=] |p| with a "{{QuotaExceededError}}" {{DOMException}}
-         and abort these steps, leaving |stream|'s [=[[buffer]]=] unmodified.
+         [=/reject=] |p| with a {{QuotaExceededError}} and abort these steps,
+         leaving |stream|'s [=[[buffer]]=] unmodified.
 
          Note: [=Storage quota=] only applies to files stored in a
          [=/bucket file system=].
@@ -1296,8 +1296,8 @@ runs these steps:
             concating |stream|'s [=[[buffer]]=] with a [=byte sequence=]
             containing |newSize|-|oldSize| `0x00` bytes.
          1. If the operation in the previous step failed due to exceeding the [=storage quota=],
-            [=/reject=] |p| with a "{{QuotaExceededError}}" {{DOMException}} and
-            abort these steps, leaving |stream|'s [=[[buffer]]=] unmodified.
+            [=/reject=] |p| with a {{QuotaExceededError}} and abort these steps,
+            leaving |stream|'s [=[[buffer]]=] unmodified.
 
             Note: [=Storage quota=] only applies to files stored in a
             [=/bucket file system=].
@@ -1544,7 +1544,7 @@ The <dfn method for=FileSystemSyncAccessHandle>write(|buffer|, {{FileSystemReadW
       |oldSize| &minus; (|writePosition| + |bufferSize|) bytes of |fileContents|.
 1. Let |newSize| be |head|'s [=byte sequence/length=] + |bufferSize| + |tail|'s [=byte sequence/length=].
 1. If |newSize| &minus; |oldSize| exceeds the available [=storage quota=],
-   [=throw=] a "{{QuotaExceededError}}" {{DOMException}}.
+   [=throw=] a {{QuotaExceededError}}.
 1. Set [=this=]'s [=FileSystemSyncAccessHandle/[[file]]=]'s
    [=file entry/binary data=] to the concatenation of
    |head|, the contents of |buffer| and |tail|.
@@ -1588,7 +1588,7 @@ The <dfn method for=FileSystemSyncAccessHandle>truncate(|newSize|)</dfn> method 
    |newSize|, [=throw=] a {{TypeError}}.
 1. If |newSize| is larger than |oldSize|:
    1. If |newSize| &minus; |oldSize| exceeds the available [=storage quota=],
-      [=throw=] a "{{QuotaExceededError}}" {{DOMException}}.
+      [=throw=] a {{QuotaExceededError}}.
    1. Set [=this=]'s [=FileSystemSyncAccessHandle/[[file]]=]'s to a
       [=byte sequence=] formed by concatenating |fileContents| with a
       [=byte sequence=] containing |newSize| &minus; |oldSize| 0x00 bytes.


### PR DESCRIPTION
QuotaExceededError is graduating from being a DOMException name into a new error class, in https://github.com/whatwg/webidl/pull/1465. Update creation sites to reflect this.

For now, the quota and requested properties are left at their default (null). Future work could include setting them in an informative fashion.

<!--
Thank you for contributing to the File System Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * See https://github.com/whatwg/webidl/pull/1465
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Yes, https://github.com/web-platform-tests/wpt/pull/53645 includes some updates here
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * See https://github.com/whatwg/webidl/pull/1465
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: See https://github.com/whatwg/webidl/pull/1465
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fs/171.html" title="Last updated on Sep 13, 2025, 12:41 AM UTC (c90e51b)">Preview</a> | <a href="https://whatpr.org/fs/171/28a8342...c90e51b.html" title="Last updated on Sep 13, 2025, 12:41 AM UTC (c90e51b)">Diff</a>