### PR TITLE
Add the `FileSystemFileHandle.move` method

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -825,13 +825,12 @@ given a {{USVString}} |newEntryName| and an optional
 
   1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
      with "`exclusive`" on |entry|.
+  1. Let |destinationLockResult| be "`not taken`".
 
   1. If |destinationEntry| is not `null`:
-    1. Let |destinationLockResult| be the result of
+    1. Set |destinationLockResult| to the result of
        [=file entry/lock/take|taking a lock=] with "`exclusive`"
        on |destinationEntry|.
-  1. Otherwise:
-    1. Let |destinationLockResult| be "`not taken`".
 
        Issue: Consider whether it should be possible to lock a
        [=/file system entry=] which does not (yet) exist.

--- a/index.bs
+++ b/index.bs
@@ -530,10 +530,18 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
      [=file system locator/kind=] is |locator|'s [=file system locator/kind=],
      [=file system locator/root=] is |locator|'s [=file system locator/root=], and
      [=file system locator/path=] is |destinationPath|.
+  1. If the result of [=file system locator/resolving=] |destinationLocator|
+     relative to |locator| is not null and is not [=list/is empty|empty=],
+     [=queue a storage task=] with |global| to [=/reject=] |result| with a
+     "{{InvalidModificationError}}" {{DOMException}} and abort these steps.
+
+     Note: This prevents moving a directory within itself.
+
   1. Let |destinationEntry| be the result of [=locating an entry=]
      given |destinationLocator|.
 
-  1. If |destinationDirectory| was not given:
+  1. If |destinationDirectory| was not given and
+     |destinationLocator| is not [=the same entry as=] |locator|:
     1. Let |destinationAccessResult| be the result of running
        |destinationEntry|'s [=file system entry/request access=]
        given "`readwrite`".
@@ -602,6 +610,12 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
        "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
     1. If |destinationLockResult| is "`failure`", [=/reject=] |result| with a
        "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
+
+    1. If |destinationLocator| is [=the same entry as=] |locator|,
+       [=enqueue the following steps=] to the [=file system queue=]:
+      1. [=file entry/lock/release|Release the lock=] on |entry|.
+      1. [=Queue a storage task=] with |global| to
+         [=/resolve=] |result| with `undefined`.
 
     1. If |entry| is a [=file entry=] and |isInABucketFileSystem| is false,
          run [=implementation-defined=] malware scans and safe browsing checks.

--- a/index.bs
+++ b/index.bs
@@ -552,7 +552,7 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
      "{{InvalidModificationError}}" {{DOMException}} and abort these steps.
 
   Issue: Do not allow |entry| to be moved if it is a
-  <a href=https://wicg.github.io/file-system-access/#wellknowndirectory-too-sensitive-or-dangerous>sensitive directory</a>
+  <a href=https://wicg.github.io/file-system-access/#enumdef-wellknowndirectory>well-known directory</a>.
 
   1. If |destinationAccessResult|'s
      [=file system access result/permission state=] is not
@@ -563,7 +563,12 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
        abort these steps
 
        Note: This prevents overwriting an existing file or directory which the
-       site does not have access to.
+       website does not have access to. To prevent overwriting a file which
+       the site can access, use of the
+       <a href=https://www.w3.org/TR/web-locks/>Web Locks API</a> is encouraged.
+
+       Issue(46): Make it easier to generate a uniquely-identifying string for
+       a {{FileSystemHandle}}.
 
     1. Let |settingsGlobal| be |handle|'s [=relevant settings object=]'s
        [=environment settings object/global object=].
@@ -598,23 +603,51 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
     1. If |destinationLockResult| is "`failure`", [=/reject=] |result| with a
        "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
 
-    1. If |destinationDirectory| was given:
-      1. If |entry|'s [=file system entry/parent=] is not `null`,
-         [=set/remove=] |entry| from |entry|'s [=file system entry/parent=]'s
-         [=directory entry/children=].
-      1. [=set/Append=] |entry| to |destinationDirectoryEntry|'s
-         [=directory entry/children=].
-
     1. If |entry| is a [=file entry=] and |isInABucketFileSystem| is false,
          run [=implementation-defined=] malware scans and safe browsing checks.
          If these checks fail, [=/reject=] |result| with an
          "{{AbortError}}" {{DOMException}} and abort these steps.
+
+    1. Let |sourceQueryAccess| be |entry|'s [=file system entry/query access=].
+    1. Let |sourceRequestAccess| be |entry|'s [=file system entry/request access=].
+
+    1. If |destinationDirectory| was given:
+      1. [=set/Append=] |entry| to |destinationDirectoryEntry|'s
+         [=directory entry/children=].
 
     1. Attempt to move |entry| to |destinationEntry| in the underlying file
        system. If that throws an exception, [=/reject=] |result| with that
        exception and abort these steps.
 
        Note: In some cases, moving a file or directory can fail non-atomically.
+       A file move may result in a partially-written |destinationEntry|.
+       A directory move may result in only some files or sub-folders being
+       copied to |destinationEntry|, and some containing files may themselves
+       fail to be moved atomically.
+       In both cases, |entry| will only be removed from the underlying file
+       system if all contents were successfully moved to |destinationEntry|.
+
+    1. If |destinationDirectory| was given:
+      1. If |entry|'s [=file system entry/parent=] is not `null`,
+         [=set/remove=] |entry| from |entry|'s [=file system entry/parent=]'s
+         [=directory entry/children=].
+
+    1. Set |handle|'s [=FileSystemHandle/locator=] to |destinationLocator|.
+
+       Note: This does not update other {{FileSystemHandle}}s with the same
+       [=FileSystemHandle/locator=], nor does it update any {{FileSystemHandle}}
+       which [=locate an entry|located to=] any of |handle|'s
+       [=directory entry/children=] if |handle| is a [=directory entry=].
+       Each of these handles will presumably no longer [=locate an entry=],
+       unless a new entry is created at the respective location.
+
+    1. Set |destinationEntry|'s [=file system entry/query access=] to
+       |sourceQueryAccess|.
+    1. Set |destinationEntry|'s [=file system entry/request access=] to
+       |sourceRequestAccess|.
+
+       Issue(101): Make sure this still makes sense once access check
+       algorithms are no longer associated with an entry.
 
     1. [=Enqueue the following steps=] to the [=file system queue=]:
       1. [=file entry/lock/release|Release the lock=] on |entry|.

--- a/index.bs
+++ b/index.bs
@@ -614,8 +614,12 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
        system. If that throws an exception, [=/reject=] |result| with that
        exception and abort these steps.
 
+       Note: In some cases, moving a file or directory can fail non-atomically.
+
     1. [=Enqueue the following steps=] to the [=file system queue=]:
       1. [=file entry/lock/release|Release the lock=] on |entry|.
+      1. If |destinationLockResult| is "`success`",
+         [=file entry/lock/release|release the lock=] on |destinationEntry|.
       1. [=Queue a storage task=] with |global| to
          [=/resolve=] |result| with `undefined`.
 

--- a/index.bs
+++ b/index.bs
@@ -419,242 +419,6 @@ The <dfn method for=FileSystemHandle>isSameEntry(|other|)</dfn> method steps are
 
 </div>
 
-### The {{FileSystemFileHandle/move(destinationDirectory, newEntryName)|move()}} method ### {#api-filesystemhandle-move}
-
-<div class="note domintro">
-  : await fileHhandle| . {{FileSystemFileHandle/move(newEntryName)|move}}({ {{USVString}}: |newEntryName|})
-  :: Renames the [=file system entry=] [=locate an entry|locatable=] by
-     |fileHandle|'s [=FileSystemHandle/locator=] to |newEntryName|.
-
-  : await |fileHandle| . {{FileSystemFileHandle/move(destinationDirectory)|move}}({ {{FileSystemDirectoryHandle}}: |destinationDirectory|})
-  :: Moves the [=file system entry=] [=locate an entry|locatable=] by
-     |fileHandle|'s [=FileSystemHandle/locator=] to the [=directory entry=]
-     [=locate an entry|locatable=] by |destinationDirectory|'s
-     [=FileSystemHandle/locator=], while keeping its existing name.
-
-     If the [=file system locator/root|roots=] of the respective
-     [=FileSystemHandle/locator|locators=] of |destinationDirectory| and
-     |fileHandle| are not the same, this operation might abort or fail
-     non-atomically.
-
-  : await |fileHandle| . {{FileSystemFileHandle/move(destinationDirectory, newEntryName)|move}}({ {{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|})
-  :: Moves the [=file system entry=] [=locate an entry|locatable=] by
-     |fileHandle|'s [=FileSystemHandle/locator=] to the [=directory entry=]
-     [=locate an entry|locatable=] by |destinationDirectory|'s
-     [=FileSystemHandle/locator=], as well as renaming to |newEntryName|.
-
-     If the [=file system locator/root|roots=] of the respective
-     [=FileSystemHandle/locator|locators=] of |destinationDirectory| and
-     |fileHandle| are not the same, this operation might abort or fail
-     non-atomically.
-</div>
-
-<div algorithm>
-The <dfn method for=FileSystemFileHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|)</dfn>
-method steps are to [=FileSystemFileHandle/move=] [=this=]
-given [=this=]'s {{FileSystemHandle/name}} and |destinationDirectory|.
-
-</div>
-
-<div algorithm>
-The <dfn method for=FileSystemFileHandle>move({{USVString}}: |newEntryName|)</dfn>
-method steps are to [=FileSystemFileHandle/move=] [=this=]
-given |newEntryName|.
-
-</div>
-
-<div algorithm>
-The <dfn method for=FileSystemFileHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|)</dfn>
-method steps are to [=FileSystemFileHandle/move=] [=this=]
-given |newEntryName| and |destinationDirectory|.
-
-</div>
-
-<div algorithm>
-
-To <dfn for=FileSystemFileHandle>move</dfn> a {{FileSystemFileHandle}} |handle|
-given a {{USVString}} |newEntryName| and an optional
-{{FileSystemDirectoryHandle}} |destinationDirectory|:
-
-1. Let |result| be [=a new promise=].
-1. Let |locator| be |handle|'s [=FileSystemHandle/locator=].
-1. Let |global| be |handle|'s [=relevant global object=].
-1. Let |isInABucketFileSystem| be true if
-   |handle| [=FileSystemHandle/is in a bucket file system=];
-   otherwise false.
-1. [=Enqueue the following steps=] to the [=file system queue=]:
-  1. If |newEntryName| is not a [=valid file name=],
-     [=queue a storage task=] with |global| to [=/reject=] |result|
-     with a {{TypeError}} and abort these steps.
-
-  1. Let |entry| be the result of [=locating an entry=] given |locator|.
-  1. Let |accessResult| be the result of running |entry|'s
-     [=file system entry/request access=] given "`readwrite`".
-  1. If |accessResult|'s [=file system access result/permission state=]
-     is not "{{PermissionState/granted}}", [=queue a storage task=] with
-     |global| to [=/reject=] |result| with a {{DOMException}} of
-     |accessResult|'s [=file system access result/error name=] and
-     abort these steps.
-
-  1. If |destinationDirectory| was given:
-    1. Let |destinationDirectoryLocator| be
-       |destinationDirectory|'s [=FileSystemHandle/locator=].
-    1. Let |destinationDirectoryEntry| be the result of [=locating an entry=]
-       given |destinationDirectoryLocator|.
-
-    1. Let |destinationDirectoryAccessResult| be the result of running
-       |destinationDirectoryEntry|'s
-       [=file system entry/request access=] given "`readwrite`".
-    1. If |destinationDirectoryAccessResult|'s
-       [=file system access result/permission state=]
-       is not "{{PermissionState/granted}}", [=queue a storage task=] with
-       |global| to [=/reject=] |result| with a {{DOMException}} of
-       |accessResult|'s [=file system access result/error name=] and
-       abort these steps.
-
-    1. If |destinationDirectoryLocator|'s [=file system locator/root=] is not
-       |locator|'s [=file system locator/root=], [=queue a storage task=] with
-       |global| to [=/reject=] |result| with an
-       "{{NotSupportedError}}" {{DOMException}} and abort these steps.
-
-       Issue(114): Decide which moves across file systems, if any, should be
-       supported, or if this should be left up to individual user-agent
-       implementations.
-
-    1. Let |destinationPath| be the result of [=list/clone|cloning=]
-       |destinationDirectoryLocator|'s [=file system locator/path=] and
-       [=list/append|appending=] |newEntryName|.
-  1. Otherwise:
-    1. Let |destinationPath| be the result of [=list/clone|cloning=]
-       |locator|'s [=file system locator/path=], [=list/remove|removing=]
-       the last [=list/item=], and [=list/append|appending=] |newEntryName|.
-
-  1. Let |destinationLocator| be a [=/file system locator=] whose
-     [=file system locator/kind=] is |locator|'s [=file system locator/kind=],
-     [=file system locator/root=] is |locator|'s [=file system locator/root=], and
-     [=file system locator/path=] is |destinationPath|.
-
-  1. Let |destinationEntry| be the result of [=locating an entry=]
-     given |destinationLocator|.
-
-  1. If |destinationDirectory| was not given and
-     |destinationLocator| is not [=the same entry as=] |locator|:
-    1. Let |destinationAccessResult| be the result of running
-       |destinationEntry|'s [=file system entry/request access=]
-       given "`readwrite`".
-
-       Issue(101): Make sure this still makes sense once access check algorithms
-       are no longer associated with an entry.
-  1. Otherwise:
-    1. Let |destinationAccessResult| be |destinationDirectoryAccessResult|.
-
-  1. If |destinationAccessResult|'s
-     [=file system access result/permission state=] is not
-     "{{PermissionState/granted}}":
-    1. If |destinationEntry| is not `null`, [=queue a storage task=] with
-       |global| to [=/reject=] |result| with a {{DOMException}} of
-       |destinationAccessResult|'s [=file system access result/error name=] and
-       abort these steps.
-
-       Note: This prevents overwriting an existing file or directory which the
-       website does not have access to. To prevent overwriting a file which
-       the site can access, use of the
-       <a href=https://www.w3.org/TR/web-locks/>Web Locks API</a> is encouraged.
-
-       Issue(46): Make it easier to generate a uniquely-identifying string for
-       a {{FileSystemHandle}}.
-
-    1. Let |settingsGlobal| be |handle|'s [=relevant settings object=]'s
-       [=environment settings object/global object=].
-    1. If |settingsGlobal| does not have [=transient activation=],
-       [=queue a storage task=] with |global| to [=/reject=] |result|
-       with a "{{NotAllowedError}}" {{DOMException}}.
-
-  1. If |entry| is `null`, [=queue a storage task=] with |global| to [=/reject=]
-     |result| with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
-  1. If |destinationDirectory| was given and |destinationDirectoryEntry|
-     is `null`, [=queue a storage task=] with |global| to [=/reject=] |result|
-     with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
-
-  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
-     with "`exclusive`" on |entry|.
-
-  1. If |destinationEntry| is not `null`:
-    1. Let |destinationLockResult| be the result of
-       [=file entry/lock/take|taking a lock=] with "`exclusive`"
-       on |destinationEntry|.
-  1. Otherwise:
-    1. Let |destinationLockResult| be "`not taken`".
-
-       Issue: Consider whether it should be possible to lock a
-       [=/file system entry=] which does not (yet) exist.
-
-  1. [=Queue a storage task=] with |global| to run these steps:
-    1. If |lockResult| is "`failure`", [=/reject=] |result| with a
-       "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
-    1. If |destinationLockResult| is "`failure`", [=/reject=] |result| with a
-       "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
-
-    1. If |destinationLocator| is [=the same entry as=] |locator|,
-       [=enqueue the following steps=] to the [=file system queue=]:
-      1. [=file entry/lock/release|Release the lock=] on |entry|.
-      1. [=Queue a storage task=] with |global| to
-         [=/resolve=] |result| with `undefined` and abort these steps.
-
-    1. If |isInABucketFileSystem| is false, run [=implementation-defined=]
-       malware scans and safe browsing checks. If these checks fail, [=/reject=]
-       |result| with an "{{AbortError}}" {{DOMException}} and abort these steps.
-
-    1. Let |sourceQueryAccess| be |entry|'s [=file system entry/query access=].
-    1. Let |sourceRequestAccess| be |entry|'s [=file system entry/request access=].
-
-    1. If |destinationDirectory| was given:
-      1. [=set/Append=] |entry| to |destinationDirectoryEntry|'s
-         [=directory entry/children=].
-
-    1. Attempt to move |entry| to |destinationEntry| in the underlying file
-       system. If that throws an exception, [=/reject=] |result| with that
-       exception and abort these steps.
-
-       Note: In some cases, moving a file or directory can fail non-atomically.
-       A file move might result in a partially-written |destinationEntry|.
-       A directory move might result in only some files or sub-folders being
-       copied to |destinationEntry|, and some containing files might themselves
-       fail to be moved atomically. In both cases, |entry| will only be removed
-       from the underlying file system if all contents were successfully moved
-       to |destinationEntry|.
-
-    1. If |destinationDirectory| was given:
-      1. If |entry|'s [=file system entry/parent=] is not `null`,
-         [=set/remove=] |entry| from |entry|'s [=file system entry/parent=]'s
-         [=directory entry/children=].
-
-    1. Set |handle|'s [=FileSystemHandle/locator=] to |destinationLocator|.
-
-       Note: This does not update other {{FileSystemHandle}}s with the same
-       [=FileSystemHandle/locator=]. Each of these handles will presumably no
-       longer [=locate an entry=], unless a new entry is created at the respective
-       location.
-
-    1. Set |destinationEntry|'s [=file system entry/query access=] to
-       |sourceQueryAccess|.
-    1. Set |destinationEntry|'s [=file system entry/request access=] to
-       |sourceRequestAccess|.
-
-       Issue(101): Make sure this still makes sense once access check
-       algorithms are no longer associated with an entry.
-
-    1. [=Enqueue the following steps=] to the [=file system queue=]:
-      1. [=file entry/lock/release|Release the lock=] on |entry|.
-      1. If |destinationLockResult| is "`success`",
-         [=file entry/lock/release|release the lock=] on |destinationEntry|.
-      1. [=Queue a storage task=] with |global| to
-         [=/resolve=] |result| with `undefined`.
-
-1. Return |result|.
-
-</div>
-
 ## The {{FileSystemFileHandle}} interface ## {#api-filesystemfilehandle}
 
 <xmp class=idl>
@@ -897,6 +661,242 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method s
     1. Let |handle| be the result of <a>creating a new `FileSystemSyncAccessHandle`</a>
        for |entry| in |realm|.
     1. [=/Resolve=] |result| with |handle|.
+
+1. Return |result|.
+
+</div>
+
+### The {{FileSystemFileHandle/move(destinationDirectory, newEntryName)|move()}} method ### {#api-filesystemhandle-move}
+
+<div class="note domintro">
+  : await fileHhandle| . {{FileSystemFileHandle/move(newEntryName)|move}}({ {{USVString}}: |newEntryName|})
+  :: Renames the [=file system entry=] [=locate an entry|locatable=] by
+     |fileHandle|'s [=FileSystemHandle/locator=] to |newEntryName|.
+
+  : await |fileHandle| . {{FileSystemFileHandle/move(destinationDirectory)|move}}({ {{FileSystemDirectoryHandle}}: |destinationDirectory|})
+  :: Moves the [=file system entry=] [=locate an entry|locatable=] by
+     |fileHandle|'s [=FileSystemHandle/locator=] to the [=directory entry=]
+     [=locate an entry|locatable=] by |destinationDirectory|'s
+     [=FileSystemHandle/locator=], while keeping its existing name.
+
+     If the [=file system locator/root|roots=] of the respective
+     [=FileSystemHandle/locator|locators=] of |destinationDirectory| and
+     |fileHandle| are not the same, this operation might abort or fail
+     non-atomically.
+
+  : await |fileHandle| . {{FileSystemFileHandle/move(destinationDirectory, newEntryName)|move}}({ {{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|})
+  :: Moves the [=file system entry=] [=locate an entry|locatable=] by
+     |fileHandle|'s [=FileSystemHandle/locator=] to the [=directory entry=]
+     [=locate an entry|locatable=] by |destinationDirectory|'s
+     [=FileSystemHandle/locator=], as well as renaming to |newEntryName|.
+
+     If the [=file system locator/root|roots=] of the respective
+     [=FileSystemHandle/locator|locators=] of |destinationDirectory| and
+     |fileHandle| are not the same, this operation might abort or fail
+     non-atomically.
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemFileHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|)</dfn>
+method steps are to [=FileSystemFileHandle/move=] [=this=]
+given [=this=]'s {{FileSystemHandle/name}} and |destinationDirectory|.
+
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemFileHandle>move({{USVString}}: |newEntryName|)</dfn>
+method steps are to [=FileSystemFileHandle/move=] [=this=]
+given |newEntryName|.
+
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemFileHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|)</dfn>
+method steps are to [=FileSystemFileHandle/move=] [=this=]
+given |newEntryName| and |destinationDirectory|.
+
+</div>
+
+<div algorithm>
+
+To <dfn for=FileSystemFileHandle>move</dfn> a {{FileSystemFileHandle}} |handle|
+given a {{USVString}} |newEntryName| and an optional
+{{FileSystemDirectoryHandle}} |destinationDirectory|:
+
+1. Let |result| be [=a new promise=].
+1. Let |locator| be |handle|'s [=FileSystemHandle/locator=].
+1. Let |global| be |handle|'s [=relevant global object=].
+1. Let |isInABucketFileSystem| be true if
+   |handle| [=FileSystemHandle/is in a bucket file system=];
+   otherwise false.
+1. [=Enqueue the following steps=] to the [=file system queue=]:
+  1. If |newEntryName| is not a [=valid file name=],
+     [=queue a storage task=] with |global| to [=/reject=] |result|
+     with a {{TypeError}} and abort these steps.
+
+  1. Let |entry| be the result of [=locating an entry=] given |locator|.
+  1. Let |accessResult| be the result of running |entry|'s
+     [=file system entry/request access=] given "`readwrite`".
+  1. If |accessResult|'s [=file system access result/permission state=]
+     is not "{{PermissionState/granted}}", [=queue a storage task=] with
+     |global| to [=/reject=] |result| with a {{DOMException}} of
+     |accessResult|'s [=file system access result/error name=] and
+     abort these steps.
+
+  1. If |destinationDirectory| was given:
+    1. Let |destinationDirectoryLocator| be
+       |destinationDirectory|'s [=FileSystemHandle/locator=].
+    1. Let |destinationDirectoryEntry| be the result of [=locating an entry=]
+       given |destinationDirectoryLocator|.
+
+    1. Let |destinationDirectoryAccessResult| be the result of running
+       |destinationDirectoryEntry|'s
+       [=file system entry/request access=] given "`readwrite`".
+    1. If |destinationDirectoryAccessResult|'s
+       [=file system access result/permission state=]
+       is not "{{PermissionState/granted}}", [=queue a storage task=] with
+       |global| to [=/reject=] |result| with a {{DOMException}} of
+       |accessResult|'s [=file system access result/error name=] and
+       abort these steps.
+
+    1. If |destinationDirectoryLocator|'s [=file system locator/root=] is not
+       |locator|'s [=file system locator/root=], [=queue a storage task=] with
+       |global| to [=/reject=] |result| with an
+       "{{NotSupportedError}}" {{DOMException}} and abort these steps.
+
+       Issue(114): Decide which moves across file systems, if any, should be
+       supported, or if this should be left up to individual user-agent
+       implementations.
+
+    1. Let |destinationPath| be the result of [=list/clone|cloning=]
+       |destinationDirectoryLocator|'s [=file system locator/path=] and
+       [=list/append|appending=] |newEntryName|.
+  1. Otherwise:
+    1. Let |destinationPath| be the result of [=list/clone|cloning=]
+       |locator|'s [=file system locator/path=], [=list/remove|removing=]
+       the last [=list/item=], and [=list/append|appending=] |newEntryName|.
+
+  1. Let |destinationLocator| be a [=/file system locator=] whose
+     [=file system locator/kind=] is |locator|'s [=file system locator/kind=],
+     [=file system locator/root=] is |locator|'s [=file system locator/root=], and
+     [=file system locator/path=] is |destinationPath|.
+
+  1. Let |destinationEntry| be the result of [=locating an entry=]
+     given |destinationLocator|.
+
+  1. If |destinationDirectory| was not given and
+     |destinationLocator| is not [=the same entry as=] |locator|:
+    1. Let |destinationAccessResult| be the result of running
+       |destinationEntry|'s [=file system entry/request access=]
+       given "`readwrite`".
+
+       Issue(101): Make sure this still makes sense once access check algorithms
+       are no longer associated with an entry.
+  1. Otherwise:
+    1. Let |destinationAccessResult| be |destinationDirectoryAccessResult|.
+
+  1. If |destinationAccessResult|'s
+     [=file system access result/permission state=] is not
+     "{{PermissionState/granted}}":
+    1. If |destinationEntry| is not `null`, [=queue a storage task=] with
+       |global| to [=/reject=] |result| with a {{DOMException}} of
+       |destinationAccessResult|'s [=file system access result/error name=] and
+       abort these steps.
+
+       Note: This prevents overwriting an existing file or directory which the
+       website does not have access to. To prevent overwriting a file which
+       the site can access, use of the
+       <a href=https://www.w3.org/TR/web-locks/>Web Locks API</a> is encouraged.
+
+       Issue(46): Make it easier to generate a uniquely-identifying string for
+       a {{FileSystemHandle}}.
+
+    1. Let |settingsGlobal| be |handle|'s [=relevant settings object=]'s
+       [=environment settings object/global object=].
+    1. If |settingsGlobal| does not have [=transient activation=],
+       [=queue a storage task=] with |global| to [=/reject=] |result|
+       with a "{{NotAllowedError}}" {{DOMException}}.
+
+  1. If |entry| is `null`, [=queue a storage task=] with |global| to [=/reject=]
+     |result| with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
+  1. If |destinationDirectory| was given and |destinationDirectoryEntry|
+     is `null`, [=queue a storage task=] with |global| to [=/reject=] |result|
+     with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
+
+  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
+     with "`exclusive`" on |entry|.
+
+  1. If |destinationEntry| is not `null`:
+    1. Let |destinationLockResult| be the result of
+       [=file entry/lock/take|taking a lock=] with "`exclusive`"
+       on |destinationEntry|.
+  1. Otherwise:
+    1. Let |destinationLockResult| be "`not taken`".
+
+       Issue: Consider whether it should be possible to lock a
+       [=/file system entry=] which does not (yet) exist.
+
+  1. [=Queue a storage task=] with |global| to run these steps:
+    1. If |lockResult| is "`failure`", [=/reject=] |result| with a
+       "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
+    1. If |destinationLockResult| is "`failure`", [=/reject=] |result| with a
+       "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
+
+    1. If |destinationLocator| is [=the same entry as=] |locator|,
+       [=enqueue the following steps=] to the [=file system queue=]:
+      1. [=file entry/lock/release|Release the lock=] on |entry|.
+      1. [=Queue a storage task=] with |global| to
+         [=/resolve=] |result| with `undefined` and abort these steps.
+
+    1. If |isInABucketFileSystem| is false, run [=implementation-defined=]
+       malware scans and safe browsing checks. If these checks fail, [=/reject=]
+       |result| with an "{{AbortError}}" {{DOMException}} and abort these steps.
+
+    1. Let |sourceQueryAccess| be |entry|'s [=file system entry/query access=].
+    1. Let |sourceRequestAccess| be |entry|'s [=file system entry/request access=].
+
+    1. If |destinationDirectory| was given:
+      1. [=set/Append=] |entry| to |destinationDirectoryEntry|'s
+         [=directory entry/children=].
+
+    1. Attempt to move |entry| to |destinationEntry| in the underlying file
+       system. If that throws an exception, [=/reject=] |result| with that
+       exception and abort these steps.
+
+       Note: In some cases, moving a file or directory can fail non-atomically.
+       A file move might result in a partially-written |destinationEntry|.
+       A directory move might result in only some files or sub-folders being
+       copied to |destinationEntry|, and some containing files might themselves
+       fail to be moved atomically. In both cases, |entry| will only be removed
+       from the underlying file system if all contents were successfully moved
+       to |destinationEntry|.
+
+    1. If |destinationDirectory| was given:
+      1. If |entry|'s [=file system entry/parent=] is not `null`,
+         [=set/remove=] |entry| from |entry|'s [=file system entry/parent=]'s
+         [=directory entry/children=].
+
+    1. Set |handle|'s [=FileSystemHandle/locator=] to |destinationLocator|.
+
+       Note: This does not update other {{FileSystemHandle}}s with the same
+       [=FileSystemHandle/locator=]. Each of these handles will presumably no
+       longer [=locate an entry=], unless a new entry is created at the respective
+       location.
+
+    1. Set |destinationEntry|'s [=file system entry/query access=] to
+       |sourceQueryAccess|.
+    1. Set |destinationEntry|'s [=file system entry/request access=] to
+       |sourceRequestAccess|.
+
+       Issue(101): Make sure this still makes sense once access check
+       algorithms are no longer associated with an entry.
+
+    1. [=Enqueue the following steps=] to the [=file system queue=]:
+      1. [=file entry/lock/release|Release the lock=] on |entry|.
+      1. If |destinationLockResult| is "`success`",
+         [=file entry/lock/release|release the lock=] on |destinationEntry|.
+      1. [=Queue a storage task=] with |global| to
+         [=/resolve=] |result| with `undefined`.
 
 1. Return |result|.
 

--- a/index.bs
+++ b/index.bs
@@ -614,7 +614,10 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
        system. If that throws an exception, [=/reject=] |result| with that
        exception and abort these steps.
 
-    1. [=/Resolve=] |result| with `undefined`.
+    1. [=Enqueue the following steps=] to the [=file system queue=]:
+      1. [=file entry/lock/release|Release the lock=] on |entry|.
+      1. [=Queue a storage task=] with |global| to
+         [=/resolve=] |result| with `undefined`.
 
 1. Return |result|.
 

--- a/index.bs
+++ b/index.bs
@@ -798,7 +798,7 @@ given a {{USVString}} |newEntryName| and an optional
   1. If |destinationAccessResult|'s
      [=file system access result/permission state=] is not
      "{{PermissionState/granted}}":
-    1. If |destinationEntry| is not `null`, [=queue a storage task=] with
+    1. If |destinationEntry| is not null, [=queue a storage task=] with
        |global| to [=/reject=] |result| with a {{DOMException}} of
        |destinationAccessResult|'s [=file system access result/error name=] and
        abort these steps.
@@ -817,17 +817,17 @@ given a {{USVString}} |newEntryName| and an optional
        [=queue a storage task=] with |global| to [=/reject=] |result|
        with a "{{NotAllowedError}}" {{DOMException}}.
 
-  1. If |entry| is `null`, [=queue a storage task=] with |global| to [=/reject=]
+  1. If |entry| is null, [=queue a storage task=] with |global| to [=/reject=]
      |result| with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
   1. If |destinationDirectory| was given and |destinationDirectoryEntry|
-     is `null`, [=queue a storage task=] with |global| to [=/reject=] |result|
+     is null, [=queue a storage task=] with |global| to [=/reject=] |result|
      with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
 
   1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
      with "`exclusive`" on |entry|.
   1. Let |destinationLockResult| be "`not taken`".
 
-  1. If |destinationEntry| is not `null`:
+  1. If |destinationEntry| is not null:
     1. Set |destinationLockResult| to the result of
        [=file entry/lock/take|taking a lock=] with "`exclusive`"
        on |destinationEntry|.
@@ -871,7 +871,7 @@ given a {{USVString}} |newEntryName| and an optional
        to |destinationEntry|.
 
     1. If |destinationDirectory| was given:
-      1. If |entry|'s [=file system entry/parent=] is not `null`,
+      1. If |entry|'s [=file system entry/parent=] is not null,
          [=set/remove=] |entry| from |entry|'s [=file system entry/parent=]'s
          [=directory entry/children=].
 

--- a/index.bs
+++ b/index.bs
@@ -697,21 +697,21 @@ The <dfn method for=FileSystemFileHandle>createSyncAccessHandle()</dfn> method s
 </div>
 
 <div algorithm>
-The <dfn method for=FileSystemFileHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|)</dfn>
+The <dfn method for=FileSystemFileHandle>move(|destinationDirectory|)</dfn>
 method steps are to [=FileSystemFileHandle/move=] [=this=]
 given [=this=]'s {{FileSystemHandle/name}} and |destinationDirectory|.
 
 </div>
 
 <div algorithm>
-The <dfn method for=FileSystemFileHandle>move({{USVString}}: |newEntryName|)</dfn>
+The <dfn method for=FileSystemFileHandle>move(|newEntryName|)</dfn>
 method steps are to [=FileSystemFileHandle/move=] [=this=]
 given |newEntryName|.
 
 </div>
 
 <div algorithm>
-The <dfn method for=FileSystemFileHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|)</dfn>
+The <dfn method for=FileSystemFileHandle>move(|destinationDirectory|, |newEntryName|)</dfn>
 method steps are to [=FileSystemFileHandle/move=] [=this=]
 given |newEntryName| and |destinationDirectory|.
 

--- a/index.bs
+++ b/index.bs
@@ -615,7 +615,7 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
        [=enqueue the following steps=] to the [=file system queue=]:
       1. [=file entry/lock/release|Release the lock=] on |entry|.
       1. [=Queue a storage task=] with |global| to
-         [=/resolve=] |result| with `undefined`.
+         [=/resolve=] |result| with `undefined` and abort these steps.
 
     1. If |entry| is a [=file entry=] and |isInABucketFileSystem| is false,
          run [=implementation-defined=] malware scans and safe browsing checks.

--- a/index.bs
+++ b/index.bs
@@ -448,21 +448,21 @@ The <dfn method for=FileSystemHandle>isSameEntry(|other|)</dfn> method steps are
 
 <div algorithm>
 The <dfn method for=FileSystemHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|)</dfn>
-method steps are to [=FileSystemHandle/move=] |handle|
-given |handle|'s {{FileSystemHandle/name}} and |destinationDirectory|.
+method steps are to [=FileSystemHandle/move=] [=this=]
+given [=this=]'s {{FileSystemHandle/name}} and |destinationDirectory|.
 
 </div>
 
 <div algorithm>
 The <dfn method for=FileSystemHandle>move({{USVString}}: |newEntryName|)</dfn>
-method steps are to [=FileSystemHandle/move=] |handle|
+method steps are to [=FileSystemHandle/move=] [=this=]
 given |newEntryName|.
 
 </div>
 
 <div algorithm>
 The <dfn method for=FileSystemHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|)</dfn>
-method steps are to [=FileSystemHandle/move=] |handle|
+method steps are to [=FileSystemHandle/move=] [=this=]
 given |newEntryName| and |destinationDirectory|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -335,9 +335,6 @@ interface FileSystemHandle {
   readonly attribute USVString name;
 
   Promise<boolean> isSameEntry(FileSystemHandle other);
-  Promise<undefined> move(USVString newEntryName);
-  Promise<undefined> move(FileSystemDirectoryHandle destinationDirectory);
-  Promise<undefined> move(FileSystemDirectoryHandle destinationDirectory, USVString newEntryName);
 };
 </xmp>
 
@@ -422,56 +419,62 @@ The <dfn method for=FileSystemHandle>isSameEntry(|other|)</dfn> method steps are
 
 </div>
 
-### The {{FileSystemHandle/move(destinationDirectory, newEntryName)|move()}} method ### {#api-filesystemhandle-move}
+### The {{FileSystemFileHandle/move(destinationDirectory, newEntryName)|move()}} method ### {#api-filesystemhandle-move}
 
 <div class="note domintro">
-  : await |handle| . {{FileSystemHandle/move(newEntryName)|move}}({ {{USVString}}: |newEntryName|})
+  : await fileHhandle| . {{FileSystemFileHandle/move(newEntryName)|move}}({ {{USVString}}: |newEntryName|})
   :: Renames the [=file system entry=] [=locate an entry|locatable=] by
-     |handle|'s [=FileSystemHandle/locator=] to |newEntryName|.
+     |fileHandle|'s [=FileSystemHandle/locator=] to |newEntryName|.
 
-  : await |handle| . {{FileSystemHandle/move(destinationDirectory)|move}}({ {{FileSystemDirectoryHandle}}: |destinationDirectory|})
+  : await |fileHandle| . {{FileSystemFileHandle/move(destinationDirectory)|move}}({ {{FileSystemDirectoryHandle}}: |destinationDirectory|})
   :: Moves the [=file system entry=] [=locate an entry|locatable=] by
-     |handle|'s [=FileSystemHandle/locator=] to the [=directory entry=]
+     |fileHandle|'s [=FileSystemHandle/locator=] to the [=directory entry=]
      [=locate an entry|locatable=] by |destinationDirectory|'s
      [=FileSystemHandle/locator=], while keeping its existing name.
 
-  : await |handle| . {{FileSystemHandle/move(destinationDirectory, newEntryName)|move}}({ {{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|})
+     If the [=file system locator/root|roots=] of the respective
+     [=FileSystemHandle/locator|locators=] of |destinationDirectory| and
+     |fileHandle| are not the same, this operation might abort or fail
+     non-atomically.
+
+  : await |fileHandle| . {{FileSystemFileHandle/move(destinationDirectory, newEntryName)|move}}({ {{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|})
   :: Moves the [=file system entry=] [=locate an entry|locatable=] by
-     |handle|'s [=FileSystemHandle/locator=] to the [=directory entry=]
+     |fileHandle|'s [=FileSystemHandle/locator=] to the [=directory entry=]
      [=locate an entry|locatable=] by |destinationDirectory|'s
      [=FileSystemHandle/locator=], as well as renaming to |newEntryName|.
 
      If the [=file system locator/root|roots=] of the respective
      [=FileSystemHandle/locator|locators=] of |destinationDirectory| and
-     |handle| are not the same, this operation may abort or fail non-atomically.
+     |fileHandle| are not the same, this operation might abort or fail
+     non-atomically.
 </div>
 
 <div algorithm>
-The <dfn method for=FileSystemHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|)</dfn>
-method steps are to [=FileSystemHandle/move=] [=this=]
+The <dfn method for=FileSystemFileHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|)</dfn>
+method steps are to [=FileSystemFileHandle/move=] [=this=]
 given [=this=]'s {{FileSystemHandle/name}} and |destinationDirectory|.
 
 </div>
 
 <div algorithm>
-The <dfn method for=FileSystemHandle>move({{USVString}}: |newEntryName|)</dfn>
-method steps are to [=FileSystemHandle/move=] [=this=]
+The <dfn method for=FileSystemFileHandle>move({{USVString}}: |newEntryName|)</dfn>
+method steps are to [=FileSystemFileHandle/move=] [=this=]
 given |newEntryName|.
 
 </div>
 
 <div algorithm>
-The <dfn method for=FileSystemHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|)</dfn>
-method steps are to [=FileSystemHandle/move=] [=this=]
+The <dfn method for=FileSystemFileHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|)</dfn>
+method steps are to [=FileSystemFileHandle/move=] [=this=]
 given |newEntryName| and |destinationDirectory|.
 
 </div>
 
 <div algorithm>
 
-To <dfn for=FileSystemHandle>move</dfn> a {{FileSystemHandle}} |handle| given
-a {{USVString}} |newEntryName| and
-an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
+To <dfn for=FileSystemFileHandle>move</dfn> a {{FileSystemFileHandle}} |handle|
+given a {{USVString}} |newEntryName| and an optional
+{{FileSystemDirectoryHandle}} |destinationDirectory|:
 
 1. Let |result| be [=a new promise=].
 1. Let |locator| be |handle|'s [=FileSystemHandle/locator=].
@@ -530,12 +533,6 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
      [=file system locator/kind=] is |locator|'s [=file system locator/kind=],
      [=file system locator/root=] is |locator|'s [=file system locator/root=], and
      [=file system locator/path=] is |destinationPath|.
-  1. If the result of [=file system locator/resolving=] |destinationLocator|
-     relative to |locator| is not null and is not [=list/is empty|empty=],
-     [=queue a storage task=] with |global| to [=/reject=] |result| with a
-     "{{InvalidModificationError}}" {{DOMException}} and abort these steps.
-
-     Note: This prevents moving a directory within itself.
 
   1. Let |destinationEntry| be the result of [=locating an entry=]
      given |destinationLocator|.
@@ -551,24 +548,13 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
   1. Otherwise:
     1. Let |destinationAccessResult| be |destinationDirectoryAccessResult|.
 
-  1. Let |isTheRootOfABucketFileSystem| be true if
-     |isInABucketFileSystem| is true and
-     |entry|'s [=file system entry/parent=] is `null`;
-     otherwise false.
-  1. If |isTheRootOfABucketFileSystem| is true,
-     [=queue a storage task=] with |global| to [=/reject=] |result| with a
-     "{{InvalidModificationError}}" {{DOMException}} and abort these steps.
-
-  Issue: Do not allow |entry| to be moved if it is a
-  <a href=https://wicg.github.io/file-system-access/#enumdef-wellknowndirectory>well-known directory</a>.
-
   1. If |destinationAccessResult|'s
      [=file system access result/permission state=] is not
      "{{PermissionState/granted}}":
     1. If |destinationEntry| is not `null`, [=queue a storage task=] with
        |global| to [=/reject=] |result| with a {{DOMException}} of
        |destinationAccessResult|'s [=file system access result/error name=] and
-       abort these steps
+       abort these steps.
 
        Note: This prevents overwriting an existing file or directory which the
        website does not have access to. To prevent overwriting a file which
@@ -593,8 +579,6 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
   1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
      with "`exclusive`" on |entry|.
 
-     Issue(137): Support locking directory entries.
-
   1. If |destinationEntry| is not `null`:
     1. Let |destinationLockResult| be the result of
        [=file entry/lock/take|taking a lock=] with "`exclusive`"
@@ -617,10 +601,9 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
       1. [=Queue a storage task=] with |global| to
          [=/resolve=] |result| with `undefined` and abort these steps.
 
-    1. If |entry| is a [=file entry=] and |isInABucketFileSystem| is false,
-         run [=implementation-defined=] malware scans and safe browsing checks.
-         If these checks fail, [=/reject=] |result| with an
-         "{{AbortError}}" {{DOMException}} and abort these steps.
+    1. If |isInABucketFileSystem| is false, run [=implementation-defined=]
+       malware scans and safe browsing checks. If these checks fail, [=/reject=]
+       |result| with an "{{AbortError}}" {{DOMException}} and abort these steps.
 
     1. Let |sourceQueryAccess| be |entry|'s [=file system entry/query access=].
     1. Let |sourceRequestAccess| be |entry|'s [=file system entry/request access=].
@@ -634,12 +617,12 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
        exception and abort these steps.
 
        Note: In some cases, moving a file or directory can fail non-atomically.
-       A file move may result in a partially-written |destinationEntry|.
-       A directory move may result in only some files or sub-folders being
-       copied to |destinationEntry|, and some containing files may themselves
-       fail to be moved atomically.
-       In both cases, |entry| will only be removed from the underlying file
-       system if all contents were successfully moved to |destinationEntry|.
+       A file move might result in a partially-written |destinationEntry|.
+       A directory move might result in only some files or sub-folders being
+       copied to |destinationEntry|, and some containing files might themselves
+       fail to be moved atomically. In both cases, |entry| will only be removed
+       from the underlying file system if all contents were successfully moved
+       to |destinationEntry|.
 
     1. If |destinationDirectory| was given:
       1. If |entry|'s [=file system entry/parent=] is not `null`,
@@ -649,11 +632,9 @@ an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
     1. Set |handle|'s [=FileSystemHandle/locator=] to |destinationLocator|.
 
        Note: This does not update other {{FileSystemHandle}}s with the same
-       [=FileSystemHandle/locator=], nor does it update any {{FileSystemHandle}}
-       which [=locate an entry|located to=] any of |handle|'s
-       [=directory entry/children=] if |handle| is a [=directory entry=].
-       Each of these handles will presumably no longer [=locate an entry=],
-       unless a new entry is created at the respective location.
+       [=FileSystemHandle/locator=]. Each of these handles will presumably no
+       longer [=locate an entry=], unless a new entry is created at the respective
+       location.
 
     1. Set |destinationEntry|'s [=file system entry/query access=] to
        |sourceQueryAccess|.
@@ -687,6 +668,10 @@ interface FileSystemFileHandle : FileSystemHandle {
   Promise<FileSystemWritableFileStream> createWritable(optional FileSystemCreateWritableOptions options = {});
   [Exposed=DedicatedWorker]
   Promise<FileSystemSyncAccessHandle> createSyncAccessHandle();
+
+  Promise<undefined> move(USVString newEntryName);
+  Promise<undefined> move(FileSystemDirectoryHandle destinationDirectory);
+  Promise<undefined> move(FileSystemDirectoryHandle destinationDirectory, USVString newEntryName);
 };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -335,6 +335,9 @@ interface FileSystemHandle {
   readonly attribute USVString name;
 
   Promise<boolean> isSameEntry(FileSystemHandle other);
+  Promise<undefined> move(USVString newEntryName);
+  Promise<undefined> move(FileSystemDirectoryHandle destinationDirectory);
+  Promise<undefined> move(FileSystemDirectoryHandle destinationDirectory, USVString newEntryName);
 };
 </xmp>
 
@@ -416,6 +419,204 @@ The <dfn method for=FileSystemHandle>isSameEntry(|other|)</dfn> method steps are
      [=/resolve=] |p| with true.
   1. Otherwise [=/resolve=] |p| with false.
 1. Return |p|.
+
+</div>
+
+### The {{FileSystemHandle/move(destinationDirectory, newEntryName)|move()}} method ### {#api-filesystemhandle-move}
+
+<div class="note domintro">
+  : await |handle| . {{FileSystemHandle/move(newEntryName)|move}}({ {{USVString}}: |newEntryName|})
+  :: Renames the [=file system entry=] [=locate an entry|locatable=] by
+     |handle|'s [=FileSystemHandle/locator=] to |newEntryName|.
+
+  : await |handle| . {{FileSystemHandle/move(destinationDirectory)|move}}({ {{FileSystemDirectoryHandle}}: |destinationDirectory|})
+  :: Moves the [=file system entry=] [=locate an entry|locatable=] by
+     |handle|'s [=FileSystemHandle/locator=] to the [=directory entry=]
+     [=locate an entry|locatable=] by |destinationDirectory|'s
+     [=FileSystemHandle/locator=], while keeping its existing name.
+
+  : await |handle| . {{FileSystemHandle/move(destinationDirectory, newEntryName)|move}}({ {{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|})
+  :: Moves the [=file system entry=] [=locate an entry|locatable=] by
+     |handle|'s [=FileSystemHandle/locator=] to the [=directory entry=]
+     [=locate an entry|locatable=] by |destinationDirectory|'s
+     [=FileSystemHandle/locator=], as well as renaming to |newEntryName|.
+
+     If the [=file system locator/root|roots=] of the respective
+     [=FileSystemHandle/locator|locators=] of |destinationDirectory| and
+     |handle| are not the same, this operation may abort or fail non-atomically.
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|)</dfn>
+method steps are to [=FileSystemHandle/move=] |handle|
+given |handle|'s {{FileSystemHandle/name}} and |destinationDirectory|.
+
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemHandle>move({{USVString}}: |newEntryName|)</dfn>
+method steps are to [=FileSystemHandle/move=] |handle|
+given |newEntryName|.
+
+</div>
+
+<div algorithm>
+The <dfn method for=FileSystemHandle>move({{FileSystemDirectoryHandle}}: |destinationDirectory|, {{USVString}}: |newEntryName|)</dfn>
+method steps are to [=FileSystemHandle/move=] |handle|
+given |newEntryName| and |destinationDirectory|.
+
+</div>
+
+<div algorithm>
+
+To <dfn for=FileSystemHandle>move</dfn> a {{FileSystemHandle}} |handle| given
+a {{USVString}} |newEntryName| and
+an optional {{FileSystemDirectoryHandle}} |destinationDirectory|:
+
+1. Let |result| be [=a new promise=].
+1. Let |locator| be |handle|'s [=FileSystemHandle/locator=].
+1. Let |global| be |handle|'s [=relevant global object=].
+1. Let |isInABucketFileSystem| be true if
+   |handle| [=FileSystemHandle/is in a bucket file system=];
+   otherwise false.
+1. [=Enqueue the following steps=] to the [=file system queue=]:
+  1. If |newEntryName| is not a [=valid file name=],
+     [=queue a storage task=] with |global| to [=/reject=] |result|
+     with a {{TypeError}} and abort these steps.
+
+  1. Let |entry| be the result of [=locating an entry=] given |locator|.
+  1. Let |accessResult| be the result of running |entry|'s
+     [=file system entry/request access=] given "`readwrite`".
+  1. If |accessResult|'s [=file system access result/permission state=]
+     is not "{{PermissionState/granted}}", [=queue a storage task=] with
+     |global| to [=/reject=] |result| with a {{DOMException}} of
+     |accessResult|'s [=file system access result/error name=] and
+     abort these steps.
+
+  1. If |destinationDirectory| was given:
+    1. Let |destinationDirectoryLocator| be
+       |destinationDirectory|'s [=FileSystemHandle/locator=].
+    1. Let |destinationDirectoryEntry| be the result of [=locating an entry=]
+       given |destinationDirectoryLocator|.
+
+    1. Let |destinationDirectoryAccessResult| be the result of running
+       |destinationDirectoryEntry|'s
+       [=file system entry/request access=] given "`readwrite`".
+    1. If |destinationDirectoryAccessResult|'s
+       [=file system access result/permission state=]
+       is not "{{PermissionState/granted}}", [=queue a storage task=] with
+       |global| to [=/reject=] |result| with a {{DOMException}} of
+       |accessResult|'s [=file system access result/error name=] and
+       abort these steps.
+
+    1. If |destinationDirectoryLocator|'s [=file system locator/root=] is not
+       |locator|'s [=file system locator/root=], [=queue a storage task=] with
+       |global| to [=/reject=] |result| with an
+       "{{NotSupportedError}}" {{DOMException}} and abort these steps.
+
+       Issue(114): Decide which moves across file systems, if any, should be
+       supported, or if this should be left up to individual user-agent
+       implementations.
+
+    1. Let |destinationPath| be the result of [=list/clone|cloning=]
+       |destinationDirectoryLocator|'s [=file system locator/path=] and
+       [=list/append|appending=] |newEntryName|.
+  1. Otherwise:
+    1. Let |destinationPath| be the result of [=list/clone|cloning=]
+       |locator|'s [=file system locator/path=], [=list/remove|removing=]
+       the last [=list/item=], and [=list/append|appending=] |newEntryName|.
+
+  1. Let |destinationLocator| be a [=/file system locator=] whose
+     [=file system locator/kind=] is |locator|'s [=file system locator/kind=],
+     [=file system locator/root=] is |locator|'s [=file system locator/root=], and
+     [=file system locator/path=] is |destinationPath|.
+  1. Let |destinationEntry| be the result of [=locating an entry=]
+     given |destinationLocator|.
+
+  1. If |destinationDirectory| was not given:
+    1. Let |destinationAccessResult| be the result of running
+       |destinationEntry|'s [=file system entry/request access=]
+       given "`readwrite`".
+
+       Issue(101): Make sure this still makes sense once access check algorithms
+       are no longer associated with an entry.
+  1. Otherwise:
+    1. Let |destinationAccessResult| be |destinationDirectoryAccessResult|.
+
+  1. Let |isTheRootOfABucketFileSystem| be true if
+     |isInABucketFileSystem| is true and
+     |entry|'s [=file system entry/parent=] is `null`;
+     otherwise false.
+  1. If |isTheRootOfABucketFileSystem| is true,
+     [=queue a storage task=] with |global| to [=/reject=] |result| with a
+     "{{InvalidModificationError}}" {{DOMException}} and abort these steps.
+
+  Issue: Do not allow |entry| to be moved if it is a
+  <a href=https://wicg.github.io/file-system-access/#wellknowndirectory-too-sensitive-or-dangerous>sensitive directory</a>
+
+  1. If |destinationAccessResult|'s
+     [=file system access result/permission state=] is not
+     "{{PermissionState/granted}}":
+    1. If |destinationEntry| is not `null`, [=queue a storage task=] with
+       |global| to [=/reject=] |result| with a {{DOMException}} of
+       |destinationAccessResult|'s [=file system access result/error name=] and
+       abort these steps
+
+       Note: This prevents overwriting an existing file or directory which the
+       site does not have access to.
+
+    1. Let |settingsGlobal| be |handle|'s [=relevant settings object=]'s
+       [=environment settings object/global object=].
+    1. If |settingsGlobal| does not have [=transient activation=],
+       [=queue a storage task=] with |global| to [=/reject=] |result|
+       with a "{{NotAllowedError}}" {{DOMException}}.
+
+  1. If |entry| is `null`, [=queue a storage task=] with |global| to [=/reject=]
+     |result| with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
+  1. If |destinationDirectory| was given and |destinationDirectoryEntry|
+     is `null`, [=queue a storage task=] with |global| to [=/reject=] |result|
+     with a "{{NotFoundError}}" {{DOMException}} and abort these steps.
+
+  1. Let |lockResult| be the result of [=file entry/lock/take|taking a lock=]
+     with "`exclusive`" on |entry|.
+
+     Issue(137): Support locking directory entries.
+
+  1. If |destinationEntry| is not `null`:
+    1. Let |destinationLockResult| be the result of
+       [=file entry/lock/take|taking a lock=] with "`exclusive`"
+       on |destinationEntry|.
+  1. Otherwise:
+    1. Let |destinationLockResult| be "`not taken`".
+
+       Issue: Consider whether it should be possible to lock a
+       [=/file system entry=] which does not (yet) exist.
+
+  1. [=Queue a storage task=] with |global| to run these steps:
+    1. If |lockResult| is "`failure`", [=/reject=] |result| with a
+       "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
+    1. If |destinationLockResult| is "`failure`", [=/reject=] |result| with a
+       "{{NoModificationAllowedError}}" {{DOMException}} and abort these steps.
+
+    1. If |destinationDirectory| was given:
+      1. If |entry|'s [=file system entry/parent=] is not `null`,
+         [=set/remove=] |entry| from |entry|'s [=file system entry/parent=]'s
+         [=directory entry/children=].
+      1. [=set/Append=] |entry| to |destinationDirectoryEntry|'s
+         [=directory entry/children=].
+
+    1. If |entry| is a [=file entry=] and |isInABucketFileSystem| is false,
+         run [=implementation-defined=] malware scans and safe browsing checks.
+         If these checks fail, [=/reject=] |result| with an
+         "{{AbortError}}" {{DOMException}} and abort these steps.
+
+    1. Attempt to move |entry| to |destinationEntry| in the underlying file
+       system. If that throws an exception, [=/reject=] |result| with that
+       exception and abort these steps.
+
+    1. [=/Resolve=] |result| with `undefined`.
+
+1. Return |result|.
 
 </div>
 


### PR DESCRIPTION
<!--
Thank you for contributing to the File System Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

An earlier version of this was proposed in https://github.com/whatwg/fs/pull/10, but stalled out due to complications around moving directories.

When looking into it, I was therefore surprised to find that this method (at least, a subset of it) has shipped in browsers since late 2021!

Apparently, Firefox and WebKit both shipped (early versions of) this method without a flag, and have kept them ever since. Chromium added *and has shipped* these methods to the public IDL of `FileSystemFileHandle`. [They did so in a commit that claimed only to remove them from `FileSystemHandle`.](https://source.chromium.org/chromium/chromium/src/+/34c937cb2f8f0ecbe1bdc404226b2e3de1f2601b) (A [slightly-later update](https://source.chromium.org/chromium/chromium/src/+/f5483e3386f6c6d047567b8b0cb40141d95d27c5) changed the single-argument version from `rename` to `move`.)

I've taken #10 and adjusted it to match what Chrome has actually been shipping, in the hope that it can be standardized and documented. In particular, directory entries can no longer be moved, and the `move` method has been moved from `FileSystemHandle` to `FileSystemFileHandle`.

Aside from just moving things around in the spec, there are a couple other changes:

- I've reworded the non-normative sections slightly, since Bikeshed now warns if you use the word "may" in a non-normative section.

- I've removed a couple steps in the algorithm that only exist to handle edge cases around moving directories. These steps were ensuring a directory could not be moved within itself, and ensuring the root of a bucket file system could not be moved.

The rewording is in its own commit, to make it easier to review that diff specifically.

- [x] At least two implementers are interested (and none opposed):
   * [Firefox has already implemented these methods, but on `FileSystemHandle`.](https://searchfox.org/firefox-main/rev/1932ff4b242ad49ef567414a943e0afacbccd6ae/dom/webidl/FileSystemHandle.webidl#17-22)
   * [Chromium has already implemented these methods.](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/file_system_access/file_system_file_handle.idl;l=43-59;drc=4d5984aff5f65e0abc32590f6e96ac8b1b0931ce)
   * [WebKit has already implemented the two-argument version of this method, but on `FileSystemHandle`.](https://github.com/WebKit/WebKit/blob/9ac33ef78924d5f0c356587123825ba1c05097b1/Source/WebCore/Modules/filesystem/FileSystemHandle.idl#L42)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/blob/master/fs/script-tests/FileSystemFileHandle-move.js
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: … (Needs to move the existing methods from `FileSystemHandle` to `FileSystemFileHandle`)
   * WebKit: … (Needs to move the existing method from `FileSystemHandle` to `FileSystemFileHandle`, and add the other two overload signatures)
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 27, 2026, 11:49 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fvaladaptive%2Ffs%2Fcf9efc4214e22239f1e8494766885187c5db74dd%2Findex.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20180)

**Error output:**

```json
[
    {
        "lineNum": "113",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": "247",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": "358",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": "767",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": "793",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": "811",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": "890",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": "984",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": "1125",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": "1206",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": "1277",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": "1713",
        "messageType": "fatal",
        "text": "Saw numeric issue markup, but can't find either a GitHub repo or manual Issue Tracker Template to format it."
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/fs%23180.)._

</details>
