### PR TITLE
fs: Remove nullable markers from WriteParams members

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1105,9 +1105,9 @@ enum WriteCommandType {
 
 dictionary WriteParams {
   required WriteCommandType type;
-  unsigned long long? size;
-  unsigned long long? position;
-  (BufferSource or Blob or USVString)? data;
+  unsigned long long size;
+  unsigned long long position;
+  (BufferSource or Blob or USVString) data;
 };
 
 typedef (BufferSource or Blob or USVString or WriteParams) FileSystemWriteChunkType;


### PR DESCRIPTION
 `size`, `position`, and `data` in the `WriteParams` dictionary were
  marked as nullable (?), but the write() algorithm only checks for their
  existence and never handles null values. Making them non-nullable means
  that passing null will now throw a TypeError at the WebIDL boundary,
  which is the correct behavior.

  Fixes #181.

  This is a spec alignment fix. The algorithm has never handled null for
  these members, so making them non-nullable correctly reflects actual
  intended behavior (also consistent with Chromium, Gecko, and WebKit
  implementations).

  - [ ] At least two implementers are interested (and none opposed):
     * N/A — this is a spec alignment fix, not a new feature
  - [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can
  be reviewed and commented upon at:
     * https://github.com/web-platform-tests/wpt/pull/58156
  - [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
     * Chromium: https://issues.chromium.org/issues/490640057
     * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2021767
     * WebKit: https://bugs.webkit.org/show_bug.cgi?id=309446
  - [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
  - [ ] The top of this comment includes a [clear commit
  message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. ✓